### PR TITLE
Update login redirect to projects ccbilling

### DIFF
--- a/webapp/src/lib/components/Login.svelte
+++ b/webapp/src/lib/components/Login.svelte
@@ -54,7 +54,7 @@
 
 	function onClick() {
 		if (loggedIn) {
-			goto('/home');
+			goto('/projects/ccbilling');
 			return;
 		}
 		if (client) {

--- a/webapp/src/routes/auth/+server.js
+++ b/webapp/src/routes/auth/+server.js
@@ -95,7 +95,7 @@ export async function GET({ request, platform }) {
 			// Changed from empty string to null for clarity
 			status: HTML_TEMPORARY_REDIRECT,
 			headers: {
-				Location: `${url.origin}/home`,
+				Location: `${url.origin}/projects/ccbilling`,
 				'Set-Cookie': `auth=${newAuth}; Expires=${expiration.toUTCString()}; Path=/; Secure; HttpOnly; SameSite=Lax`
 			}
 		});

--- a/webapp/src/routes/auth/auth.test.js
+++ b/webapp/src/routes/auth/auth.test.js
@@ -18,7 +18,7 @@ describe('Auth', () => {
 		server = createServer({
 			routes() {
 				this.get('https://fintechnick.com', () => ({}));
-				this.get('https://fintechnick.com/home', (x) => x);
+				this.get('https://fintechnick.com/projects/ccbilling', (x) => x);
 				this.post('https://oauth2.googleapis.com/token', () => ({
 					access_token: 'mock_access_token',
 					expires_in: 3600
@@ -50,7 +50,7 @@ describe('Auth', () => {
 			}
 		});
 
-		expect(res.headers.get('Location')).toEqual('https://fintechnick.com/home');
+		expect(res.headers.get('Location')).toEqual('https://fintechnick.com/projects/ccbilling');
 	});
 
 	it('redirect to preview if not in KV', async () => {


### PR DESCRIPTION
Change post-login redirect location from `/home` to `/projects/ccbilling`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-e4644160-1924-4a45-8535-3e85185d6adc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e4644160-1924-4a45-8535-3e85185d6adc)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)