### PR TITLE
Fix Cloudflare adapter build error

### DIFF
--- a/webapp/wrangler.jsonc
+++ b/webapp/wrangler.jsonc
@@ -2,7 +2,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "ftn",
 	"compatibility_date": "2024-05-30",
-	// "main" is intentionally not set at the top level for `wrangler dev`
+	"main": ".svelte-kit/cloudflare/_worker.js",
 	"assets": {
 		"binding": "ASSETS",
 		"directory": ".svelte-kit/cloudflare"


### PR DESCRIPTION
Add `main` key to `wrangler.jsonc` to fix build error with `@sveltejs/adapter-cloudflare` v7.1.1.

The error "You must set the `main` key... or remove the `assets.binding` key" occurred because the newer adapter version introduced stricter validation. As this is a full-stack SvelteKit application utilizing Cloudflare Workers (D1, KV, R2 bindings), the correct fix was to add the `main` key, ensuring the adapter correctly processes the Worker alongside static assets.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6234b857-10a8-45de-bcfd-97c10d0fd991) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6234b857-10a8-45de-bcfd-97c10d0fd991)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)