### PR TITLE
Fix awk space handling for object keys

### DIFF
--- a/webapp/populate_local_r2_from_prod.sh
+++ b/webapp/populate_local_r2_from_prod.sh
@@ -88,8 +88,9 @@ sync_bucket() {
             continue
         fi
         
-        # Extract object key (first column, handling spaces in filenames)
-        local object_key=$(echo "$line" | awk '{print $1}')
+        # Extract object key (first column, properly handling spaces in filenames)
+        # Use tab or multiple spaces as delimiter, take everything up to the first delimiter
+        local object_key=$(echo "$line" | sed 's/[[:space:]]\{2,\}.*//' | sed 's/\t.*//')
         
         if [[ -z "$object_key" ]]; then
             continue


### PR DESCRIPTION
Fix object key extraction to correctly handle spaces in filenames.

The previous `awk '{print $1}'` command incorrectly truncated object keys at the first space. This PR replaces it with `sed` commands that remove content after two or more spaces or a tab, preserving single spaces within the object key, aligning with the comment's intention.

---

[Open in Web](https://cursor.com/agents?id=bc-6d2735b4-a02f-464d-bf16-8748b9aa355e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6d2735b4-a02f-464d-bf16-8748b9aa355e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)