### PR TITLE
Configure dependabot to ignore remark-footnotes upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "remark-footnotes"
+        # Keep at v2.x as later versions break footnote functionality
       
   - package-ecosystem: "github-actions"
     # Workflow files stored in the


### PR DESCRIPTION
Add `remark-footnotes` to Dependabot ignore list to prevent upgrades that break functionality.

---

[Open in Web](https://cursor.com/agents?id=bc-6e1450fb-6ca6-42d7-bf19-ceaa55d1631f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6e1450fb-6ca6-42d7-bf19-ceaa55d1631f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)