### PR TITLE
Remove always true not equal to undefined check

### DIFF
--- a/webapp/src/lib/server/route-utils.js
+++ b/webapp/src/lib/server/route-utils.js
@@ -58,8 +58,8 @@ export class RouteUtils {
 	 * @param {string} value - Parameter value
 	 * @param {string} paramName - Parameter name for error messages
 	 * @param {Object} options - Validation options
-	 * @param {number} options.min - Minimum value
-	 * @param {number} options.max - Maximum value
+	 * @param {number} [options.min] - Minimum value
+	 * @param {number} [options.max] - Maximum value
 	 * @returns {number|string} - Parsed integer or error message
 	 */
 	static parseInteger(value, paramName, options = {}) {


### PR DESCRIPTION
Correct JSDoc for optional parameters in `parseInteger` to resolve a linter warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-238bd7c2-2554-431f-90c6-c6967f525f15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-238bd7c2-2554-431f-90c6-c6967f525f15">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>