### PR TITLE
Make notauthorised link clickable

### DIFF
--- a/webapp/src/lib/components/Button.svelte
+++ b/webapp/src/lib/components/Button.svelte
@@ -26,7 +26,7 @@
 		lg: 'py-3 px-6 text-lg'
 	};
 
-	const classes = `font-bold rounded ${variants[variant]} ${sizes[size]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} no-underline`;
+	const classes = `font-bold rounded ${variants[variant]} ${sizes[size]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} no-underline not-prose inline-block`;
 </script>
 
 {#if href}

--- a/webapp/src/routes/notauthorised/+page.svelte
+++ b/webapp/src/routes/notauthorised/+page.svelte
@@ -78,7 +78,7 @@
 						href="/projects/dbt-duckdb"
 						variant="primary"
 						size="lg"
-						class="whitespace-normal text-center"
+						class="whitespace-normal text-center block w-fit mx-auto"
 					>
 						Read: Modern ETL with dbt & DuckDB
 					</Button>


### PR DESCRIPTION
Restore button styling for the 'Read: ...' link on the notauthorised route by preventing global CSS overrides.

---
<a href="https://cursor.com/background-agent?bcId=bc-586c9999-822f-40c7-a82c-bace6594ed72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-586c9999-822f-40c7-a82c-bace6594ed72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>