### PR TITLE
Fix button class prop override issue

### DIFF
--- a/webapp/src/lib/components/Button.svelte
+++ b/webapp/src/lib/components/Button.svelte
@@ -26,15 +26,22 @@
 		lg: 'py-3 px-6 text-lg'
 	};
 
-	const classes = `font-bold rounded ${variants[variant]} ${sizes[size]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} no-underline not-prose inline-block`;
+	const defaultClasses = `font-bold rounded ${variants[variant]} ${sizes[size]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} no-underline not-prose inline-block`;
+	
+	// Extract class from rest and merge with default classes
+	const customClass = rest.class || '';
+	const classes = `${defaultClasses} ${customClass}`.trim();
+	
+	// Remove class from rest to avoid conflicts
+	const { class: _, ...restWithoutClass } = rest;
 </script>
 
 {#if href}
-	<a {href} class={classes} {...rest}>
+	<a {href} class={classes} {...restWithoutClass}>
 		{@render children?.()}
 	</a>
 {:else}
-	<button {type} {disabled} class={classes} {onclick} {...rest}>
+	<button {type} {disabled} class={classes} {onclick} {...restWithoutClass}>
 		{@render children?.()}
 	</button>
 {/if}


### PR DESCRIPTION
Merge custom `class` prop with default Button component classes to prevent overrides.

Previously, passing a `class` prop to the Button component would entirely replace its default classes (e.g., `not-prose`, `inline-block`) due to the order of attribute spreading. This fix extracts the `class` from `rest`, combines it with the component's default classes, and then spreads the remaining `rest` props, ensuring both default and custom styles are applied correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-c299ff93-0574-4f54-89f0-988cfcd02f06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c299ff93-0574-4f54-89f0-988cfcd02f06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>