### PR TITLE
Update main page github links to ftn repo

### DIFF
--- a/webapp/src/lib/components/Footer.svelte
+++ b/webapp/src/lib/components/Footer.svelte
@@ -46,7 +46,7 @@
 					<EnvelopeRegular /></a
 				>
 				<a
-					href="https://github.com/nickbrett1/"
+					href="https://github.com/nickbrett1/ftn"
 					class=" -mt-1 size-[48px] p-1 flex items-center justify-center"
 				>
 					<GithubBrands />

--- a/webapp/src/lib/components/Header.svelte
+++ b/webapp/src/lib/components/Header.svelte
@@ -23,7 +23,7 @@
 		>
 			<LinkedinInBrands aria-label="LinkedIn" />
 		</a>
-		<a href="https://github.com/nickbrett1/" class="p-1 text-white flex items-center size-[48px]">
+		<a href="https://github.com/nickbrett1/ftn" class="p-1 text-white flex items-center size-[48px]">
 			<GithubBrands />
 		</a>
 		<a


### PR DESCRIPTION
Update GitHub links in header and footer to point to the FTN repository.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c9cdedb-27e5-4b5a-8c77-3fb00edcb81e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c9cdedb-27e5-4b5a-8c77-3fb00edcb81e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>