### PR TITLE
Investigate circleci test exit status 1

### DIFF
--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -43,16 +43,17 @@ export default defineConfig(({ command, mode }) => {
 			environment: 'jsdom',
 			coverage: {
 				reporter: ['text', 'lcov'],
-				// Reduce memory usage by limiting coverage collection
+				// Simplify coverage configuration for better CI stability
 				exclude: [
 					'node_modules/**',
 					'tests/**',
 					'**/*.test.{js,ts}',
 					'**/*.spec.{js,ts}',
 					'**/*.config.{js,ts}',
-					'**/*.setup.{js,ts}'
+					'**/*.setup.{js,ts}',
+					'**/*.stories.{js,ts}'
 				],
-				// Limit coverage to essential files
+				// Include all source files
 				include: [
 					'src/**/*.{js,ts}'
 				]
@@ -63,11 +64,14 @@ export default defineConfig(({ command, mode }) => {
 			hookTimeout: 30000,
 			// Limit concurrent tests to reduce memory usage
 			maxConcurrency: 2,
-			// Reduce memory usage
+			// Use forks pool with stable configuration for CI
 			pool: 'forks',
 			poolOptions: {
 				forks: {
-					singleFork: true
+					// Use multiple forks for better stability
+					singleFork: false,
+					// Add memory limit to prevent issues
+					memoryLimit: '2GB'
 				}
 			}
 		},


### PR DESCRIPTION
Adjust Vitest configuration to resolve mysterious CI test failures.

Tests were passing locally but failing in CircleCI with exit code 1. The issue was traced to the `pool: 'forks'` configuration with `singleFork: true` causing instability in the CI environment. This PR changes `singleFork` to `false` and adds a `memoryLimit` for better stability, and refines coverage exclusions.

---
<a href="https://cursor.com/background-agent?bcId=bc-f703c2b9-90cf-4233-a703-93dac167d3bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f703c2b9-90cf-4233-a703-93dac167d3bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

