### PR TITLE
Fix billing cycle invalidation

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -189,7 +189,7 @@
 				throw new Error(errorData.error || 'Failed to delete billing cycle');
 			}
 			// Invalidate the cache to ensure fresh data is loaded
-			await invalidate('statements');
+			await invalidate('/projects/ccbilling');
 			await goto('/projects/ccbilling');
 		} catch (err) {
 			deleteError = err.message;


### PR DESCRIPTION
Update cache invalidation identifier to correctly refresh the billing cycles list after deleting a billing cycle.

---
<a href="https://cursor.com/background-agent?bcId=bc-808b62b0-737b-46ac-9fe0-2d149189864f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-808b62b0-737b-46ac-9fe0-2d149189864f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

