### PR TITLE
Fix unresponsive add new budget button

### DIFF
--- a/.vite/deps/_metadata.json
+++ b/.vite/deps/_metadata.json
@@ -1,0 +1,8 @@
+{
+  "hash": "027ea33e",
+  "configHash": "3eec0cc5",
+  "lockfileHash": "e3b0c442",
+  "browserHash": "1ff1bc3b",
+  "optimized": {},
+  "chunks": {}
+}

--- a/.vite/deps/package.json
+++ b/.vite/deps/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/webapp/src/lib/components/Button.svelte
+++ b/webapp/src/lib/components/Button.svelte
@@ -6,6 +6,7 @@
 		disabled = false,
 		href = null,
 		children,
+		onclick = null,
 		...rest
 	} = $props();
 
@@ -26,11 +27,11 @@
 	};
 
 	const defaultClasses = `font-bold rounded ${variants[variant]} ${sizes[size]} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'} no-underline not-prose inline-block`;
-	
+
 	// Extract class from rest and merge with default classes
 	const customClass = rest.class || '';
 	const classes = `${defaultClasses} ${customClass}`.trim();
-	
+
 	// Remove class from rest to avoid conflicts
 	const { class: _, ...restWithoutClass } = rest;
 </script>
@@ -40,7 +41,7 @@
 		{@render children?.()}
 	</a>
 {:else}
-	<button {type} {disabled} class={classes} {...restWithoutClass}>
+	<button {type} {disabled} class={classes} on:click={onclick} {...restWithoutClass}>
 		{@render children?.()}
 	</button>
 {/if}

--- a/webapp/src/routes/projects/ccbilling/budgets/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/budgets/+page.svelte
@@ -280,7 +280,7 @@
 	<div class="mt-8 flex space-x-4">
 		{#if !showAddForm}
 			<Button
-				onclick={() => (showAddForm = true)}
+				onclick={() => showAddForm = true}
 				variant="success"
 				size="lg"
 				style="cursor: pointer;"

--- a/webapp/src/routes/projects/ccbilling/budgets/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/budgets/+page.svelte
@@ -8,20 +8,20 @@
 	const { budgets = [] } = data;
 
 	// Add budget state
-	let showAddForm = false;
-	let newBudgetName = '';
-	let isAdding = false;
-	let addError = '';
+	let showAddForm = $state(false);
+	let newBudgetName = $state('');
+	let isAdding = $state(false);
+	let addError = $state('');
 
 	// Edit budget state
-	let editingBudget = null;
-	let editName = '';
-	let isEditing = false;
-	let editError = '';
+	let editingBudget = $state(null);
+	let editName = $state('');
+	let isEditing = $state(false);
+	let editError = $state('');
 
 	// Delete state
-	let deletingBudget = null;
-	let isDeleting = false;
+	let deletingBudget = $state(null);
+	let isDeleting = $state(false);
 
 	async function addBudget() {
 		if (!newBudgetName.trim()) {

--- a/webapp/tests/button-component.test.js
+++ b/webapp/tests/button-component.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import Button from '../src/lib/components/Button.svelte';
+
+describe('Button Component', () => {
+	it('should handle onclick events correctly', async () => {
+		const mockOnClick = vi.fn();
+		
+		const { getByRole } = render(Button, {
+			props: {
+				onclick: mockOnClick,
+				children: () => 'Test Button'
+			}
+		});
+
+		const button = getByRole('button');
+		expect(button).toBeTruthy();
+		expect(button.textContent).toBe('Test Button');
+
+		// Click the button
+		await fireEvent.click(button);
+
+		// Verify the onclick handler was called
+		expect(mockOnClick).toHaveBeenCalledTimes(1);
+	});
+
+	it('should render as a link when href is provided', () => {
+		const { container } = render(Button, {
+			props: {
+				href: '/test-link',
+				children: () => 'Link Button'
+			}
+		});
+
+		const link = container.querySelector('a');
+		expect(link).toBeTruthy();
+		expect(link.href).toContain('/test-link');
+		expect(link.textContent).toBe('Link Button');
+	});
+
+	it('should apply correct classes based on variant and size', () => {
+		const { getByRole } = render(Button, {
+			props: {
+				variant: 'success',
+				size: 'lg',
+				children: () => 'Styled Button'
+			}
+		});
+
+		const button = getByRole('button');
+		expect(button.className).toContain('bg-green-600');
+		expect(button.className).toContain('py-3 px-6');
+	});
+});


### PR DESCRIPTION
Make budget page state variables reactive and update Button component event handling for Svelte 5 compatibility.

The 'Add New Budget' button was not functioning because its associated state variable (`showAddForm`) and other related state variables on the budgets page were not declared as reactive using `$state()` as required by Svelte 5. This PR updates these declarations to ensure proper reactivity. It also updates the `Button` component to explicitly bind the `onclick` prop using `on:click={onclick}` for better Svelte 5 compatibility and adds a new test for the `Button` component's event handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-12f5c44f-3662-42ee-9e73-9be35fe3bd18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12f5c44f-3662-42ee-9e73-9be35fe3bd18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

