### PR TITLE
Fix budget management page reactivity

### DIFF
--- a/webapp/src/routes/projects/ccbilling/budgets/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/budgets/+page.svelte
@@ -8,20 +8,20 @@
 	const { budgets = [] } = data;
 
 	// Add budget state
-	let showAddForm = false;
-	let newBudgetName = '';
-	let isAdding = false;
-	let addError = '';
+	let showAddForm = $state(false);
+	let newBudgetName = $state('');
+	let isAdding = $state(false);
+	let addError = $state('');
 
 	// Edit budget state
-	let editingBudget = null;
-	let editName = '';
-	let isEditing = false;
-	let editError = '';
+	let editingBudget = $state(null);
+	let editName = $state('');
+	let isEditing = $state(false);
+	let editError = $state('');
 
 	// Delete state
-	let deletingBudget = null;
-	let isDeleting = false;
+	let deletingBudget = $state(null);
+	let isDeleting = $state(false);
 
 	async function addBudget() {
 		if (!newBudgetName.trim()) {


### PR DESCRIPTION
Made budget management page variables reactive to ensure UI updates correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-f385cf73-2185-488e-a5a9-0acb0b71756c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f385cf73-2185-488e-a5a9-0acb0b71756c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

