### PR TITLE
Center align budget icon picker grid icons

### DIFF
--- a/webapp/src/routes/projects/ccbilling/budgets/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/budgets/+page.svelte
@@ -206,7 +206,7 @@
 							<button
 								type="button"
 								onclick={() => (newBudgetIcon = icon)}
-								class="p-2 text-2xl rounded transition-colors {newBudgetIcon === icon
+								class="p-2 text-2xl rounded transition-colors flex items-center justify-center {newBudgetIcon === icon
 									? 'bg-blue-600'
 									: isUsed
 										? 'bg-gray-700 text-gray-500 cursor-not-allowed'
@@ -285,7 +285,7 @@
 											<button
 												type="button"
 												onclick={() => (editIcon = icon)}
-												class="p-2 text-2xl rounded transition-colors {editIcon === icon
+												class="p-2 text-2xl rounded transition-colors flex items-center justify-center {editIcon === icon
 													? 'bg-blue-600'
 													: isUsed
 														? 'bg-gray-700 text-gray-500 cursor-not-allowed'

--- a/webapp/src/routes/projects/ccbilling/budgets/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/budgets/[id]/+page.svelte
@@ -198,7 +198,7 @@
 						<button
 							type="button"
 							onclick={() => (editIcon = icon)}
-							class="p-2 text-2xl rounded transition-colors {editIcon === icon
+							class="p-2 text-2xl rounded transition-colors flex items-center justify-center {editIcon === icon
 								? 'bg-blue-600'
 								: isUsed
 									? 'bg-gray-700 text-gray-500 cursor-not-allowed'


### PR DESCRIPTION
Center aligns icons in the budget icon picker grid for improved visual presentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-aba9094f-b5e6-49b8-81c6-38869429e74e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aba9094f-b5e6-49b8-81c6-38869429e74e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

