### PR TITLE
Hide parse button after successful parse

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -103,6 +103,11 @@
 	// Determine if we should use radio buttons (for small number of budgets)
 	let shouldUseRadioButtons = $derived(data.budgets.length <= 5);
 
+	// Function to check if a statement has been parsed (has associated charges)
+	function isStatementParsed(statementId) {
+		return data.charges.some(charge => charge.statement_id === statementId);
+	}
+
 	function showCardInfo(cardName) {
 		// Prevent multiple rapid clicks
 		if (isShowingCardInfo) return;
@@ -563,22 +568,28 @@
 								</p>
 							</div>
 							<div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
-								<Button
-									type="button"
-									variant="success"
-									size="sm"
-									disabled={parsingStatements.has(statement.id)}
-									onclick={() => parseStatement(statement.id)}
-								>
-									{#if parsingStatements.has(statement.id)}
-										<div class="flex items-center space-x-2">
-											<div class="animate-spin rounded-full h-3 w-3 border-b-2 border-white"></div>
-											<span>Parsing...</span>
-										</div>
-									{:else}
-										Parse
-									{/if}
-								</Button>
+								{#if !isStatementParsed(statement.id)}
+									<Button
+										type="button"
+										variant="success"
+										size="sm"
+										disabled={parsingStatements.has(statement.id)}
+										onclick={() => parseStatement(statement.id)}
+									>
+										{#if parsingStatements.has(statement.id)}
+											<div class="flex items-center space-x-2">
+												<div class="animate-spin rounded-full h-3 w-3 border-b-2 border-white"></div>
+												<span>Parsing...</span>
+											</div>
+										{:else}
+											Parse
+										{/if}
+									</Button>
+								{:else}
+									<div class="text-green-400 text-sm font-medium px-3 py-1 bg-green-900/20 border border-green-700 rounded">
+										✓ Parsed
+									</div>
+								{/if}
 								<Button
 									type="button"
 									variant="danger"


### PR DESCRIPTION
Hide the statement parse button once a statement has been parsed to prevent accidental re-parsing and provide clear status.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fe3626c-1a2d-45d9-88cb-4d51344e66c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2fe3626c-1a2d-45d9-88cb-4d51344e66c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

