### PR TITLE
Fix icon inconsistency for Red Cross

### DIFF
--- a/webapp/src/lib/utils/budget-icons.js
+++ b/webapp/src/lib/utils/budget-icons.js
@@ -117,7 +117,7 @@ export function getDefaultIcon(budgetName) {
  * Get allocation icon for display
  */
 export function getAllocationIcon(allocation, budgets = []) {
-	if (!allocation || allocation === '') return '❌';
+	if (!allocation || allocation === '' || allocation === 'Unallocated') return '❌';
 
 	// Find the budget with this name and get its icon
 	const budget = budgets.find((b) => b.name === allocation);


### PR DESCRIPTION
Ensure unallocated icon is consistently a Red Cross across charges and totals sections.

---
<a href="https://cursor.com/background-agent?bcId=bc-92f8886f-5787-4624-8070-8972640ece0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92f8886f-5787-4624-8070-8972640ece0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

