### PR TITLE
Fix missing running totals on phone

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -871,9 +871,9 @@
 		<div class="container mx-auto max-w-6xl">
 			<div class="flex flex-col items-start gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
 				<div class="text-white font-medium flex-shrink-0">Running Totals:</div>
-				<div class="flex items-center gap-4 w-full overflow-x-auto whitespace-nowrap md:flex-wrap md:whitespace-normal">
+				<div class="flex flex-wrap items-center gap-3 w-full">
 					{#each sortedAllocationTotals as [allocation, total]}
-						<div class="flex items-center gap-2 flex-shrink-0">
+						<div class="flex items-center gap-2">
 							<span class="text-lg">{getAllocationIcon(allocation === '__unallocated__' ? null : allocation, localData.budgets)}</span>
 							<span class="text-gray-300 text-sm">{allocation === '__unallocated__' ? 'Unallocated' : allocation}:</span>
 							<span class="text-white font-medium {total < 0 ? 'text-red-400' : ''}">

--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -867,7 +867,7 @@
 
 <!-- Fixed Footer with Running Totals -->
 {#if localData.charges.length > 0}
-	<div class="fixed bottom-0 left-0 right-0 bg-gray-900 border-t border-gray-700 p-4 z-40">
+	<div class="fixed bottom-0 left-0 right-0 bg-gray-900 border-t border-gray-700 p-4 z-50">
 		<div class="container mx-auto max-w-6xl">
 			<div class="flex flex-wrap items-center justify-between gap-4">
 				<div class="text-white font-medium">Running Totals:</div>

--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -867,13 +867,13 @@
 
 <!-- Fixed Footer with Running Totals -->
 {#if localData.charges.length > 0}
-	<div class="fixed bottom-0 left-0 right-0 bg-gray-900 border-t border-gray-700 p-4 z-50">
+	<div class="fixed bottom-0 left-0 right-0 bg-gray-900 border-t border-gray-700 p-4 pb-[env(safe-area-inset-bottom)] z-50">
 		<div class="container mx-auto max-w-6xl">
-			<div class="flex flex-wrap items-center justify-between gap-4">
-				<div class="text-white font-medium">Running Totals:</div>
-				<div class="flex flex-wrap items-center gap-4">
+			<div class="flex flex-col items-start gap-3 md:flex-row md:items-center md:justify-between md:gap-4">
+				<div class="text-white font-medium flex-shrink-0">Running Totals:</div>
+				<div class="flex items-center gap-4 w-full overflow-x-auto whitespace-nowrap md:flex-wrap md:whitespace-normal">
 					{#each sortedAllocationTotals as [allocation, total]}
-						<div class="flex items-center gap-2">
+						<div class="flex items-center gap-2 flex-shrink-0">
 							<span class="text-lg">{getAllocationIcon(allocation === '__unallocated__' ? null : allocation, localData.budgets)}</span>
 							<span class="text-gray-300 text-sm">{allocation === '__unallocated__' ? 'Unallocated' : allocation}:</span>
 							<span class="text-white font-medium {total < 0 ? 'text-red-400' : ''}">


### PR DESCRIPTION
Increase running totals footer z-index to resolve mobile visibility.

The footer was previously hidden behind other fixed elements on mobile due to a lower z-index, making it invisible when changing allocations.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac0af952-909a-41e0-9135-2dfbd90a60a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac0af952-909a-41e0-9135-2dfbd90a60a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

