### PR TITLE
Fix mobile running total overlay on navigation

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -852,7 +852,7 @@
 	{/if}
 
 	{#if !showUploadForm}
-		<div>
+		<div class="mb-8">
 			<Button href="/projects/ccbilling" variant="secondary" size="lg"
 				>Back to Billing Cycles</Button
 			>


### PR DESCRIPTION
Add bottom margin to 'Back to Billing Cycles' button to prevent overlay by fixed running totals footer on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-c81329cc-e556-4493-afa3-d180ae1a56fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c81329cc-e556-4493-afa3-d180ae1a56fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

