### PR TITLE
Update budgets detail page auto-save

### DIFF
--- a/webapp/src/routes/projects/ccbilling/budgets/[id]/svelte.test.js
+++ b/webapp/src/routes/projects/ccbilling/budgets/[id]/svelte.test.js
@@ -103,7 +103,6 @@ describe('Budget Detail Page - Svelte Coverage', () => {
 		expect(container.innerHTML).toContain('Add Merchant');
 		expect(container.innerHTML).toContain('Remove');
 		expect(container.innerHTML).toContain('Back to Budgets');
-		expect(container.innerHTML).toContain('Save Changes');
 	});
 
 	it('handles merchant name variations', () => {


### PR DESCRIPTION
Remove 'Save Changes' button and implement immediate saving of budget name and icon changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee478631-0047-4d6e-aaea-3911b2c419b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee478631-0047-4d6e-aaea-3911b2c419b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

