### PR TITLE
Fix red line on edit credit card screen

### DIFF
--- a/webapp/src/routes/projects/ccbilling/cards/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/cards/[id]/+page.svelte
@@ -120,8 +120,9 @@ async function handleDelete() {
 				data-testid="edit-card-last4-input"
 			/>
 		</div>
-		<!-- Always render the save error div, no visibility:hidden, always show content -->
-		<div class="bg-red-900 border border-red-700 text-red-200 px-4 py-2 rounded mb-4" data-testid="save-error">{saveError}</div>
+		{#if saveError}
+			<div class="bg-red-900 border border-red-700 text-red-200 px-4 py-2 rounded mb-4" data-testid="save-error">{saveError}</div>
+		{/if}
 		<!-- Remove the Save Changes button and only keep the Back to Cards button -->
 		<div class="flex gap-2 mt-4">
 			<Button href="/projects/ccbilling/cards" variant="secondary" size="md">Back to Cards</Button>


### PR DESCRIPTION
Conditionally render the save error message div to remove the persistent red line above the 'Back to Cards' button when no error is present.

---
<a href="https://cursor.com/background-agent?bcId=bc-26d7c218-6bc0-43f2-b613-c0be6ff50d7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-26d7c218-6bc0-43f2-b613-c0be6ff50d7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

