### PR TITLE
Remove back to billing cycles button

### DIFF
--- a/webapp/src/routes/projects/ccbilling/cards/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/cards/+page.svelte
@@ -193,11 +193,11 @@
 			>
 				Add Credit Card
 			</button>
+			<a
+				href="/projects/ccbilling"
+				class="font-bold rounded bg-gray-900 hover:bg-gray-800 text-gray-300 border border-gray-600 hover:border-gray-500 py-3 px-6 text-lg cursor-pointer no-underline not-prose inline-block"
+				>Back to Billing Cycles</a
+			>
 		{/if}
-		<a
-			href="/projects/ccbilling"
-			class="font-bold rounded bg-gray-900 hover:bg-gray-800 text-gray-300 border border-gray-600 hover:border-gray-500 py-3 px-6 text-lg cursor-pointer no-underline not-prose inline-block"
-			>Back to Billing Cycles</a
-		>
 	</div>
 </PageLayout>


### PR DESCRIPTION
Conditionally hides the 'Back to Billing Cycles' button on the 'Add New Credit Card' page to avoid confusion with the 'Cancel' button.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d1dd5a5-5b2e-4f6f-b04c-73fc94305b83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d1dd5a5-5b2e-4f6f-b04c-73fc94305b83">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

