### PR TITLE
Move merchant details icon before name

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -731,6 +731,7 @@
 						<div class="flex justify-between items-start gap-3">
 							<div class="flex-1 min-w-0">
 								<div class="text-white font-medium truncate">
+									<button class="mr-2 text-gray-400 hover:text-white" title="More info about this merchant" onclick={() => openMerchantInfo(charge.id)}>❓</button>
 									{#if charge.flight_details}
 										✈️ {formatMerchantName(charge)}
 									{:else if charge.is_foreign_currency && formatForeignCurrency(charge)}
@@ -738,7 +739,6 @@
 									{:else}
 										{formatMerchantName(charge)}
 									{/if}
-									<button class="ml-2 text-gray-400 hover:text-white" title="More info about this merchant" onclick={() => openMerchantInfo(charge.id)}>❓</button>
 								</div>
 								<div class="text-gray-400 text-sm mt-1 flex items-center gap-2">
 									<span
@@ -830,6 +830,7 @@
 									</span>
 								</td>
 								<td class="text-white py-2">
+									<button class="mr-2 text-gray-400 hover:text-white align-middle" title="More info about this merchant" onclick={() => openMerchantInfo(charge.id)}>❓</button>
 									{#if charge.flight_details}
 										✈️ {formatMerchantName(charge)}
 									{:else if charge.is_foreign_currency && formatForeignCurrency(charge)}
@@ -837,7 +838,6 @@
 									{:else}
 										{formatMerchantName(charge)}
 									{/if}
-									<button class="ml-2 text-gray-400 hover:text-white align-middle" title="More info about this merchant" onclick={() => openMerchantInfo(charge.id)}>❓</button>
 								</td>
 								<td class="text-gray-300 text-sm py-2">
 									{#if charge.card_name}


### PR DESCRIPTION
Move the merchant info icon before the name to prevent clipping on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-eaf54a40-c130-4713-b93e-9fe108eb5ce0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eaf54a40-c130-4713-b93e-9fe108eb5ce0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

