### PR TITLE
Sync doppler secrets to cloudflare

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,13 +181,11 @@ jobs:
           name: Sync Doppler secrets to Cloudflare (production)
           command: |
             cd webapp
-            export CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN:-$CLOUDFLARE_DOPPLER_TOKEN}"
             npx wrangler secret:bulk --env production <(doppler secrets --json | jq -c 'with_entries(.value = .value.computed)')
       - run:
           name: Deploying to Cloudflare
           command: |
             cd webapp
-            export CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN:-$CLOUDFLARE_DOPPLER_TOKEN}"
             npm run deploy
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,9 +174,21 @@ jobs:
           command: |
             cd webapp && ./setup-wrangler-config.sh
       - run:
+          name: Install jq
+          command: |
+            sudo apt-get update && sudo apt-get install -y jq
+      - run:
+          name: Sync Doppler secrets to Cloudflare (production)
+          command: |
+            cd webapp
+            export CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN:-$CLOUDFLARE_DOPPLER_TOKEN}"
+            npx wrangler secret:bulk --env production <(doppler secrets --json | jq -c 'with_entries(.value = .value.computed)')
+      - run:
           name: Deploying to Cloudflare
           command: |
-            cd webapp && npm run deploy
+            cd webapp
+            export CLOUDFLARE_API_TOKEN="${CLOUDFLARE_API_TOKEN:-$CLOUDFLARE_DOPPLER_TOKEN}"
+            npm run deploy
 
 workflows:
   build_test_deploy:

--- a/webapp/setup-wrangler-config.sh
+++ b/webapp/setup-wrangler-config.sh
@@ -20,9 +20,16 @@ if [ ! -f "wrangler.template.jsonc" ]; then
     exit 1
 fi
 
+# Build doppler args if a config override is provided
+DOPPLER_ARGS=""
+if [ -n "$DOPPLER_CONFIG" ]; then
+    DOPPLER_ARGS="--config $DOPPLER_CONFIG"
+    echo "Using Doppler config: $DOPPLER_CONFIG"
+fi
+
 # Run doppler to get environment variables and execute the configuration generation
 echo "Fetching environment variables from Doppler..."
-doppler run -- bash -c '
+doppler run $DOPPLER_ARGS -- bash -c '
     # Check if required environment variables are set
     if [ -z "$KV_NAMESPACE_ID" ]; then
         echo "Error: KV_NAMESPACE_ID environment variable is not set in Doppler"


### PR DESCRIPTION
Add Cloudflare secret sync to CircleCI deploy job to automate syncing Doppler secrets to Cloudflare Workers.

This PR integrates `wrangler secret:bulk` into the CircleCI deploy pipeline, ensuring `jq` is installed and `wrangler` correctly uses the `CLOUDFLARE_DOPPLER_TOKEN` by aliasing it to `CLOUDFLARE_API_TOKEN`. It also adds support for `DOPPLER_CONFIG` override in the `setup-wrangler-config.sh` script.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee08be1b-f34b-4efe-ada2-c71c049c8e47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee08be1b-f34b-4efe-ada2-c71c049c8e47">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

