### PR TITLE
Handle unknown wrangler arguments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
           name: Sync Doppler secrets to Cloudflare (production)
           command: |
             cd webapp
-            npx wrangler secret:bulk --env production <(doppler secrets --json | jq -c 'with_entries(.value = .value.computed)')
+            doppler secrets --json | jq -c 'with_entries(.value = .value.computed)' | npx wrangler secret bulk --env production
       - run:
           name: Deploying to Cloudflare
           command: |


### PR DESCRIPTION
Replaced deprecated `wrangler secret:bulk` with `wrangler secret bulk` to fix "Unknown arguments" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-da18bcd8-497e-4a9d-a541-7cd041c54034">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da18bcd8-497e-4a9d-a541-7cd041c54034">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

