### PR TITLE
Fix credit card filter combo box bug

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -787,7 +787,7 @@
 						>
 							<option value="all">All Cards</option>
 							{#each localData.creditCards as card}
-								<option value={card.id}>{card.name} (****{card.last4})</option>
+								<option value={card.id.toString()}>{card.name} (****{card.last4})</option>
 							{/each}
 						</select>
 						{#if selectedCardFilter !== 'all'}


### PR DESCRIPTION
Fix credit card filter combo box showing blank by ensuring type consistency between button click and select options.

The issue stemmed from a type mismatch: credit card filter buttons set the `selectedCardFilter` state as a string, while the select dropdown options used number values. Svelte's binding requires exact type and value matches for the selected option to display correctly. By converting the option values to strings, the select box now correctly reflects the filter applied by the buttons.

---
<a href="https://cursor.com/background-agent?bcId=bc-883b84c4-7a2d-4dad-baae-6e8f00b69ffb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-883b84c4-7a2d-4dad-baae-6e8f00b69ffb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

