### PR TITLE
Fix chase statement parsing for phantom charges

### DIFF
--- a/webapp/src/lib/utils/ccbilling-parsers/chase-parser.js
+++ b/webapp/src/lib/utils/ccbilling-parsers/chase-parser.js
@@ -148,8 +148,31 @@ export class ChaseParser extends BaseParser {
 			.map((line) => line.trim())
 			.filter((line) => line.length > 0);
 
+		// Flag to track if we're in the SHOP WITH POINTS ACTIVITY section
+		let inShopWithPointsSection = false;
+
 		for (let i = 0; i < lines.length; i++) {
 			const line = lines[i];
+
+			// Check if we're entering the SHOP WITH POINTS ACTIVITY section
+			if (line.toUpperCase().includes('SHOP WITH POINTS ACTIVITY')) {
+				inShopWithPointsSection = true;
+				continue;
+			}
+
+			// Check if we're exiting the SHOP WITH POINTS ACTIVITY section
+			// Look for the next major section header
+			if (inShopWithPointsSection) {
+				if (line.toUpperCase().includes('ACCOUNT ACTIVITY') || 
+					line.toUpperCase().includes('INTEREST CHARGES') ||
+					line.toUpperCase().includes('YOUR ACCOUNT MESSAGES') ||
+					line.toUpperCase().includes('ACCOUNT SUMMARY')) {
+					inShopWithPointsSection = false;
+				} else {
+					// Skip all lines while in this section
+					continue;
+				}
+			}
 
 			// Look for date pattern at the start of a line (MM/DD)
 			const dateMatch = line.match(/^(\d{2}\/\d{2})\s+(.+)/);


### PR DESCRIPTION
Exclude 'SHOP WITH POINTS ACTIVITY' section from Chase statement parsing to prevent incorrect charge detection.

---
<a href="https://cursor.com/background-agent?bcId=bc-e794d104-c4a6-4e82-8f30-8bd27e62b246">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e794d104-c4a6-4e82-8f30-8bd27e62b246">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

