### PR TITLE
Fix running totals after statement deletion

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -438,6 +438,10 @@
 				throw new Error(errorData.error || 'Failed to delete statement');
 			}
 
+			// Remove the deleted statement from local state
+			localData.statements = localData.statements.filter(statement => statement.id !== statementId);
+			localData.charges = localData.charges.filter(charge => charge.statement_id !== statementId);
+
 			// Use invalidate() - the proper SvelteKit way
 			await invalidate(`cycle-${data.cycleId}`);
 		} catch (err) {


### PR DESCRIPTION
Immediately update local state when deleting a statement to ensure running totals update instantly.

Previously, deleting a statement would remove it and its charges from the database, and `invalidate()` was called to refresh data. However, the local state (`localData.charges`) wasn't updated immediately, leading to a delay in running totals reflecting the deletion. This change ensures the local state is updated synchronously for an immediate UI refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-1dc46ca1-165b-4b45-9076-135f80f79c6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1dc46ca1-165b-4b45-9076-135f80f79c6e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

