### PR TITLE
Update statement display to prioritize card names

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -704,9 +704,11 @@
 							class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3"
 						>
 							<div class="flex-1">
-								<h4 class="text-white font-medium">{statement.filename}</h4>
+								<h4 class="text-white font-medium">
+									{card ? `${card.name} (****${card.last4})` : 'Unknown Card'}
+								</h4>
 								<p class="text-gray-400 text-sm">
-									{card ? `${card.name} (****${card.last4})` : ''}{statement.statement_date
+									{statement.filename}{statement.statement_date
 										? ` • Statement Date: ${formatLocalDate(statement.statement_date)}`
 										: ''}
 								</p>


### PR DESCRIPTION
Display card name as primary heading and filename as secondary in statements view to improve relevance for users.

---
<a href="https://cursor.com/background-agent?bcId=bc-9323fe07-32f8-4e23-b426-eac3feb524a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9323fe07-32f8-4e23-b426-eac3feb524a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

