### PR TITLE
Always show merchant add widgets

### DIFF
--- a/webapp/src/routes/projects/ccbilling/budgets/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/budgets/[id]/+page.svelte
@@ -15,7 +15,6 @@
 	const { budget = null, merchants = [] } = data;
 
 	// Add merchant state
-	let showAddForm = $state(false);
 	let selectedMerchant = $state('');
 	let isAdding = $state(false);
 	let addError = $state('');
@@ -72,7 +71,6 @@
 
 			// Reset form and refresh data
 			selectedMerchant = '';
-			showAddForm = false;
 			window.location.reload();
 		} catch (error) {
 			addError = 'Network error occurred';
@@ -109,12 +107,6 @@
 			deletingMerchant = null;
 			isDeleting = false;
 		}
-	}
-
-	function cancelAdd() {
-		showAddForm = false;
-		selectedMerchant = '';
-		addError = '';
 	}
 
 	function validateBudgetNameAndIcon(name, icon) {
@@ -255,37 +247,32 @@
 		</p>
 
 		<!-- Add Merchant Form -->
-		{#if showAddForm}
-			<div class="bg-gray-800 border border-gray-700 rounded-lg p-6 mb-6">
-				<h3 class="text-lg font-semibold text-white mb-4">Add Merchant</h3>
-				<div class="space-y-4">
-					<div>
-						<MerchantPicker
-							{selectedMerchant}
-							onSelect={(merchant) => (selectedMerchant = merchant)}
-							placeholder="Choose a merchant to assign to this budget..."
-						/>
-					</div>
-					{#if addError}
-						<p class="text-red-400 text-sm">{addError}</p>
-					{/if}
-					<div class="flex space-x-2">
-						<Button
-							onclick={addMerchant}
-							variant="success"
-							size="md"
-							disabled={isAdding}
-							style="cursor: pointer;"
-						>
-							{isAdding ? 'Adding...' : 'Add Merchant'}
-						</Button>
-						<Button onclick={cancelAdd} variant="secondary" size="md" style="cursor: pointer;">
-							Cancel
-						</Button>
-					</div>
+		<div class="bg-gray-800 border border-gray-700 rounded-lg p-6 mb-6">
+			<h3 class="text-lg font-semibold text-white mb-4">Add Merchant</h3>
+			<div class="space-y-4">
+				<div>
+					<MerchantPicker
+						{selectedMerchant}
+						onSelect={(merchant) => (selectedMerchant = merchant)}
+						placeholder="Choose a merchant to assign to this budget..."
+					/>
+				</div>
+				{#if addError}
+					<p class="text-red-400 text-sm">{addError}</p>
+				{/if}
+				<div class="flex space-x-2">
+					<Button
+						onclick={addMerchant}
+						variant="success"
+						size="md"
+						disabled={isAdding}
+						style="cursor: pointer;"
+					>
+						{isAdding ? 'Adding...' : 'Add Merchant'}
+					</Button>
 				</div>
 			</div>
-		{/if}
+		</div>
 
 		<!-- Merchants List -->
 		{#if merchants.length === 0}
@@ -322,20 +309,6 @@
 						</div>
 					{/each}
 				</div>
-			</div>
-		{/if}
-
-		<!-- Add Merchant Button -->
-		{#if !showAddForm}
-			<div class="mt-6">
-				<Button
-					onclick={() => (showAddForm = true)}
-					variant="success"
-					size="lg"
-					style="cursor: pointer;"
-				>
-					Add Merchant
-				</Button>
 			</div>
 		{/if}
 	</div>


### PR DESCRIPTION
Make merchant addition widgets always visible on the budget page to remove an unnecessary click and speed up the workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-b575ea48-b756-4c4f-8bfd-4286fcc09fcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b575ea48-b756-4c4f-8bfd-4286fcc09fcd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

