### PR TITLE
Fix long file names in statements view

### DIFF
--- a/webapp/src/app.css
+++ b/webapp/src/app.css
@@ -96,4 +96,27 @@ main a:not([class*='text-']):not(.not-prose):hover,
 	animation: var(--animate-border);
 }
 
+/* Ensure proper text truncation on mobile devices */
+.truncate {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+/* Additional mobile-specific truncation support */
+@media (max-width: 640px) {
+	.truncate {
+		max-width: 100%;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	
+	/* Ensure grid containers properly constrain width on mobile */
+	.grid {
+		width: 100%;
+		max-width: 100%;
+	}
+}
+
 

--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -712,19 +712,19 @@
 				Upload credit card statements to begin processing charges.
 			</p>
 		{:else}
-			<div class="space-y-3">
+			<div class="space-y-3 w-full">
 				{#each data.statements as statement}
 					{@const card = data.creditCards.find((c) => c.id === statement.credit_card_id)}
 					<div class="bg-gray-700 border border-gray-600 rounded-lg p-4">
 						<div
-							class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 w-full"
+							class="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-3 w-full"
 						>
-							<div class="flex-1 min-w-0">
+							<div class="min-w-0 w-full overflow-hidden max-w-full">
 								<h4 class="text-white font-medium">
 									{card ? `${card.name} (****${card.last4})` : 'Unknown Card'}
 								</h4>
-								<div class="text-gray-400 text-sm space-y-1">
-									<div class="truncate" title={statement.filename}>
+								<div class="text-gray-400 text-sm space-y-1 w-full overflow-hidden">
+									<div class="truncate w-full max-w-full overflow-hidden text-ellipsis whitespace-nowrap" title={statement.filename}>
 										{statement.filename}
 									</div>
 									{#if statement.statement_date}
@@ -735,7 +735,7 @@
 									Uploaded: {new Date(statement.uploaded_at + 'Z').toLocaleString()}
 								</p>
 							</div>
-							<div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2">
+							<div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2 justify-self-end items-start sm:items-center">
 								{#if !isStatementParsed(statement.id)}
 									<Button
 										type="button"


### PR DESCRIPTION
Refactor statements view layout to properly truncate long filenames on mobile devices.

The previous flexbox layout on mobile lacked sufficient width constraints, preventing `truncate` from working; this update uses CSS Grid and explicit width handling to ensure proper containment and ellipsis.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8359c31-1c5f-45ff-94cb-35c346c8f745">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8359c31-1c5f-45ff-94cb-35c346c8f745">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

