### PR TITLE
Align statement buttons on mobile

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -735,7 +735,7 @@
 									Uploaded: {new Date(statement.uploaded_at + 'Z').toLocaleString()}
 								</p>
 							</div>
-							<div class="flex flex-col sm:flex-row space-y-2 sm:space-y-0 sm:space-x-2 justify-self-end items-start sm:items-center">
+							<div class="flex flex-row space-x-2 justify-start sm:justify-end items-start sm:items-center">
 								{#if !isStatementParsed(statement.id)}
 									<Button
 										type="button"


### PR DESCRIPTION
Improve mobile layout for statement listing buttons to left-align and horizontally arrange them.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f559839-930b-43ed-a261-bb1714a8be92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8f559839-930b-43ed-a261-bb1714a8be92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

