### PR TITLE
Remove total entry when budget is filtered

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -1253,7 +1253,7 @@
 							</span>
 						</div>
 					{/each}
-					{#if selectedCardFilter !== 'all' || selectedBudgetFilter !== 'all'}
+					{#if selectedCardFilter !== 'all' && selectedBudgetFilter === 'all'}
 						<div class="text-gray-400 text-sm border-l border-gray-600 pl-4">
 							Total: ${getFilteredCharges().reduce((sum, charge) => sum + charge.amount, 0).toFixed(2)}
 						</div>

--- a/webapp/tests/client/ccbilling-billing-cycle-page.test.js
+++ b/webapp/tests/client/ccbilling-billing-cycle-page.test.js
@@ -415,6 +415,26 @@ describe('Billing Cycle Page - Credit Card Filtering', () => {
 			// Should not show total when showing all charges
 			expect(container.textContent).not.toContain('Total: $');
 		});
+
+		it('should not show total amount when filtering by budget', async () => {
+			const { container } = render(BillingCyclePage, mockProps);
+			await tick();
+
+			const budgetFilterSelect = container.querySelector('#budget-filter');
+			
+			// Select Shopping budget
+			fireEvent.change(budgetFilterSelect, { target: { value: 'Shopping' } });
+			await tick();
+
+			// Should show running totals for Shopping budget only
+			expect(container.textContent).toContain('Running Totals:');
+			expect(container.textContent).toContain('Shopping: $125.00');
+			expect(container.textContent).not.toContain('Food: $');
+			expect(container.textContent).not.toContain('Transportation: $');
+			
+			// Should NOT show total since it would be redundant with single budget
+			expect(container.textContent).not.toContain('Total: $');
+		});
 	});
 
 	describe('Empty State Handling', () => {


### PR DESCRIPTION
Remove redundant 'Total' entry in Running Totals when filtering by a single budget.

When filtering the billing cycle by a specific budget, the 'Running Totals' section displayed a 'Total' entry that was identical to the single budget's total, creating an unnecessary duplication. This change hides the 'Total' in this specific scenario to improve clarity, while retaining it for other filter combinations (e.g., filtering by card where multiple budget totals might still be displayed).

---
<a href="https://cursor.com/background-agent?bcId=bc-b716118e-d9bf-4748-8578-c5aa83bf8704">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b716118e-d9bf-4748-8578-c5aa83bf8704">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

