### PR TITLE
Fix merchant popup visibility on mobile

### DIFF
--- a/webapp/src/app.css
+++ b/webapp/src/app.css
@@ -119,6 +119,18 @@ main a:not([class*='text-']):not(.not-prose):hover,
 	overflow-y: auto !important;
 }
 
+/* Mobile modal positioning improvements */
+@media (max-width: 768px) {
+	.modal-backdrop {
+		align-items: flex-start !important;
+		padding-top: 1rem !important;
+	}
+	
+	.modal-backdrop > div {
+		margin-top: 0 !important;
+	}
+}
+
 .modal-container {
 	position: relative !important;
 	background-color: rgb(17, 24, 39) !important; /* gray-900 */
@@ -247,6 +259,16 @@ html, body {
 	.modal-container {
 		margin: 1rem auto;
 		max-width: calc(100vw - 2rem);
+	}
+	
+	/* Ensure modal is always visible at the top of viewport on mobile */
+	.fixed.inset-0.z-\[9999\] {
+		align-items: flex-start !important;
+	}
+	
+	/* Add top margin for mobile modal positioning */
+	.fixed.inset-0.z-\[9999\] > div {
+		margin-top: 1rem !important;
 	}
 }
 

--- a/webapp/src/lib/components/MerchantSelectionModal.svelte
+++ b/webapp/src/lib/components/MerchantSelectionModal.svelte
@@ -102,6 +102,13 @@
 					}
 				}
 			}, 100);
+			
+			// Scroll to top of modal when it opens
+			setTimeout(() => {
+				if (modalRef) {
+					modalRef.scrollTop = 0;
+				}
+			}, 50);
 		} else {
 			// Clear timeout when modal closes
 			if (focusTimeout) {
@@ -132,7 +139,7 @@
 	<!-- Modal Backdrop - Responsive positioning -->
 	<div
 		bind:this={backdropRef}
-		class="fixed inset-0 z-[9999] flex items-center justify-center p-2 sm:p-4 md:p-6 overflow-y-auto"
+		class="fixed inset-0 z-[9999] flex items-start justify-center p-2 sm:p-4 md:p-6 overflow-y-auto"
 		style="
 			position: fixed !important; 
 			top: 0 !important; 
@@ -153,7 +160,7 @@
 		<!-- Modal Container - Responsive centering -->
 		<div
 			bind:this={modalRef}
-			class="relative bg-gray-900 border border-gray-700 rounded-lg shadow-xl w-full max-w-2xl mx-4 sm:mx-6 md:mx-8"
+			class="relative bg-gray-900 border border-gray-700 rounded-lg shadow-xl w-full max-w-2xl mx-4 sm:mx-6 md:mx-8 mt-4 sm:mt-8 md:mt-12"
 			style="
 				position: relative !important; 
 				z-index: 10000 !important;
@@ -165,6 +172,7 @@
 				max-width: calc(100vw - 1rem) !important;
 				max-height: calc(100vh - 1rem) !important;
 				overflow-y: auto !important;
+				margin-top: 1rem !important;
 			"
 			role="document"
 		>


### PR DESCRIPTION
Adjust modal positioning to ensure the 'View All Merchants' popup is always visible at the top of the viewport on mobile devices without requiring scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec449014-e7d9-4815-bcb8-17af72f1790d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec449014-e7d9-4815-bcb8-17af72f1790d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

