### PR TITLE
Remove merchant from combo after budget association

### DIFF
--- a/webapp/src/lib/components/MerchantPicker.svelte
+++ b/webapp/src/lib/components/MerchantPicker.svelte
@@ -40,6 +40,9 @@
 
 	function handleModalSelect(merchant) {
 		onSelect(merchant);
+		// Refresh the recent merchants list to remove the newly added merchant
+		// This ensures the combo box doesn't show merchants that are no longer unassigned
+		loadRecentMerchants();
 	}
 
 	onMount(() => {


### PR DESCRIPTION
Remove merchants from the recent merchant combo box after they are added via the 'View All Merchants' popup to prevent unselectable entries.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb344265-cbca-4ed9-8dff-82359e0de449">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb344265-cbca-4ed9-8dff-82359e0de449">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

