### PR TITLE
Move back to budgets button to top

### DIFF
--- a/webapp/src/routes/projects/ccbilling/budgets/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/budgets/[id]/+page.svelte
@@ -231,6 +231,9 @@
 		<div>
 			<h1 class="text-4xl font-bold">{budget?.name || 'Loading...'}</h1>
 		</div>
+		<div>
+			<Button href="/projects/ccbilling/budgets" variant="secondary" size="lg">Back to Budgets</Button>
+		</div>
 	</div>
 
 	<!-- Budget Info -->
@@ -353,8 +356,6 @@
 			</div>
 		{/if}
 	</div>
-
-	<Button href="/projects/ccbilling/budgets" variant="secondary" size="lg">Back to Budgets</Button>
 
 	<!-- Delete confirmation dialog -->
 	{#if showDeleteDialog}


### PR DESCRIPTION
Move 'Back to Budgets' button to the top of the budget information page to improve accessibility and avoid scrolling on long lists of merchant assignments.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a13f293-e139-4de7-8d58-7c7952c49396">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a13f293-e139-4de7-8d58-7c7952c49396">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

