### PR TITLE
Fix merchant auto-assignment combo box bug

### DIFF
--- a/webapp/src/routes/projects/ccbilling/budgets/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/budgets/[id]/+page.svelte
@@ -77,16 +77,21 @@
 				return;
 			}
 
-			// Reset form and refresh data
+			// Reset form immediately after successful addition
 			selectedMerchant = '';
 			
-			// Refresh the merchant picker to remove the newly added merchant from the list
+			// Refresh data without page reload to maintain scroll position
+			await invalidateAll();
+			
+			// Refresh the merchant picker AFTER data invalidation to ensure it's up to date
 			if (merchantPickerRef && merchantPickerRef.refreshMerchantList) {
 				await merchantPickerRef.refreshMerchantList();
 			}
 			
-			// Refresh data without page reload to maintain scroll position
-			await invalidateAll();
+			// Also reset the merchant picker state to ensure it's completely clean
+			if (merchantPickerRef && merchantPickerRef.resetMerchantPicker) {
+				merchantPickerRef.resetMerchantPicker();
+			}
 			
 			// Restore scroll position after data refresh and remove class
 			requestAnimationFrame(() => {
@@ -126,13 +131,18 @@
 				return;
 			}
 
-			// Refresh the merchant picker to potentially add the removed merchant back to the list
+			// Refresh data without page reload to maintain scroll position
+			await invalidateAll();
+			
+			// Refresh the merchant picker AFTER data invalidation to ensure it's up to date
 			if (merchantPickerRef && merchantPickerRef.refreshMerchantList) {
 				await merchantPickerRef.refreshMerchantList();
 			}
-
-			// Refresh data without page reload to maintain scroll position
-			await invalidateAll();
+			
+			// Also reset the merchant picker state to ensure it's completely clean
+			if (merchantPickerRef && merchantPickerRef.resetMerchantPicker) {
+				merchantPickerRef.resetMerchantPicker();
+			}
 			
 			// Restore scroll position after data refresh and remove class
 			requestAnimationFrame(() => {
@@ -298,6 +308,7 @@
 						{selectedMerchant}
 						onSelect={(merchant) => (selectedMerchant = merchant)}
 						placeholder="Choose a merchant to assign to this budget..."
+						assignedMerchants={merchants.map(m => m.merchant_normalized || m.merchant)}
 						bind:this={merchantPickerRef}
 					/>
 				</div>


### PR DESCRIPTION
Fixes a bug preventing already assigned merchants from being removed from the auto-assignment combo box.

Previously, a race condition and incorrect refresh logic allowed users to re-select merchants immediately after assignment, leading to "merchant already assigned" errors. This PR ensures the combo box accurately reflects available merchants by filtering out assigned ones, correcting refresh timing, and resetting the picker's state after operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3da9b9e-2494-4a31-87c6-492f8260874f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f3da9b9e-2494-4a31-87c6-492f8260874f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

