### PR TITLE
Fix auto association prompt for charge changes

### DIFF
--- a/webapp/src/lib/components/AutoAssociationUpdateModal.svelte
+++ b/webapp/src/lib/components/AutoAssociationUpdateModal.svelte
@@ -2,32 +2,22 @@
 	import { createEventDispatcher } from 'svelte';
 	import Button from './Button.svelte';
 
-	export let isOpen = false;
-	export let merchantName = '';
-	export let currentAllocation = '';
-	export let newAllocation = '';
-	export let autoAssociationBudget = '';
+	let { isOpen = false, merchantName = '', currentAllocation = '', newAllocation = '', autoAssociationBudget = '' } = $props();
 
 	const dispatch = createEventDispatcher();
 
 	function handleUpdateAutoAssociation() {
 		dispatch('updateAutoAssociation');
-		closeModal();
 	}
 
 	function handleSkip() {
 		dispatch('skip');
-		closeModal();
-	}
-
-	function closeModal() {
-		isOpen = false;
 	}
 
 	// Close modal when clicking outside
 	function handleBackdropClick(event) {
 		if (event.target === event.currentTarget) {
-			closeModal();
+			dispatch('close');
 		}
 	}
 </script>


### PR DESCRIPTION
Ensures the auto-association update modal appears correctly when changing a charge's association.

The modal was not appearing due to a combination of Svelte 5 syntax incompatibility in the modal component and incorrect state management, which prevented the allocation change from being properly deferred.

---
<a href="https://cursor.com/background-agent?bcId=bc-61ac3842-4e13-467b-9d11-7f446a31417f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-61ac3842-4e13-467b-9d11-7f446a31417f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

