### PR TITLE
Fix popup for auto-associated charge changes

### DIFF
--- a/webapp/src/lib/components/AutoAssociationUpdateModal.svelte
+++ b/webapp/src/lib/components/AutoAssociationUpdateModal.svelte
@@ -4,6 +4,8 @@
 
 	let { isOpen = false, merchantName = '', currentAllocation = '', newAllocation = '', autoAssociationBudget = '' } = $props();
 
+	console.log('AutoAssociationUpdateModal props:', { isOpen, merchantName, currentAllocation, newAllocation, autoAssociationBudget });
+
 	const dispatch = createEventDispatcher();
 
 	function handleUpdateAutoAssociation() {
@@ -22,16 +24,21 @@
 	}
 </script>
 
+<!-- Debug info - always visible -->
+<div class="fixed top-4 right-4 bg-red-500 text-white p-2 rounded z-[9999] text-xs">
+	Modal Debug: isOpen={isOpen}, merchant={merchantName}, current={currentAllocation}, new={newAllocation}
+</div>
+
 {#if isOpen}
 	<div
-		class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+		class="fixed inset-0 bg-red-500 bg-opacity-90 flex items-center justify-center z-[9999] p-4"
 		on:click={handleBackdropClick}
 	>
-		<div class="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+		<div class="bg-yellow-300 border-4 border-red-500 rounded-lg shadow-xl max-w-md w-full p-6">
 			<div class="flex items-center mb-4">
 				<div class="flex-shrink-0">
 					<svg
-						class="h-6 w-6 text-yellow-500"
+						class="h-6 w-6 text-red-500"
 						fill="none"
 						viewBox="0 0 24 24"
 						stroke="currentColor"
@@ -44,17 +51,17 @@
 						/>
 					</svg>
 				</div>
-				<h3 class="ml-3 text-lg font-medium text-gray-900">
+				<h3 class="ml-3 text-lg font-medium text-red-900">
 					Update Auto-Association?
 				</h3>
 			</div>
 
 			<div class="mb-6">
-				<p class="text-sm text-gray-600 mb-4">
+				<p class="text-sm text-red-800 mb-4">
 					You're changing the allocation for <strong>{merchantName}</strong> from{' '}
 					<strong>{autoAssociationBudget}</strong> to <strong>{newAllocation}</strong>.
 				</p>
-				<p class="text-sm text-gray-600">
+				<p class="text-sm text-red-800">
 					Would you like to update the auto-association rule so that future charges from{' '}
 					<strong>{merchantName}</strong> will automatically be allocated to{' '}
 					<strong>{newAllocation}</strong>?

--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -288,15 +288,40 @@
 		const charge = localData.charges.find((c) => c.id === chargeId);
 		const currentAllocation = charge.allocated_to;
 		
+		console.log('updateChargeAllocation called:', { chargeId, newAllocation, currentAllocation, merchant: charge.merchant_normalized });
+		
 		// Find if there's an auto-association for this merchant
 		const autoAssociation = localData.autoAssociations.find(
 			aa => aa.merchant_normalized === charge.merchant_normalized
 		);
 		
+		console.log('Auto-association found:', autoAssociation);
+		console.log('Auto-associations data:', localData.autoAssociations);
+		
 		// Check if user is changing away from an auto-association
+		console.log('Condition check:', {
+			hasAutoAssociation: !!autoAssociation,
+			currentAllocation,
+			autoAssociationBudgetName: autoAssociation?.budget_name,
+			newAllocation,
+			currentMatchesAuto: currentAllocation === autoAssociation?.budget_name,
+			newDifferentFromAuto: newAllocation !== autoAssociation?.budget_name,
+			currentAllocationType: typeof currentAllocation,
+			autoAssociationBudgetNameType: typeof autoAssociation?.budget_name,
+			newAllocationType: typeof newAllocation
+		});
+		
 		if (autoAssociation && 
 			currentAllocation === autoAssociation.budget_name && 
 			newAllocation !== autoAssociation.budget_name) {
+			
+			console.log('Showing auto-association modal for:', {
+				merchantName: charge.merchant,
+				currentAllocation: currentAllocation || 'Unallocated',
+				newAllocation: newAllocation || 'Unallocated',
+				autoAssociationBudget: autoAssociation.budget_name,
+				chargeId: chargeId
+			});
 			
 			// Show the auto-association update modal
 			autoAssociationModalData = {
@@ -307,9 +332,11 @@
 				chargeId: chargeId // Store the charge ID for later processing
 			};
 			showAutoAssociationModal = true;
+			console.log('Modal state set:', { showAutoAssociationModal, autoAssociationModalData });
 			return; // Don't proceed with the update yet
 		}
 		
+		console.log('No auto-association change, proceeding with normal update');
 		// No auto-association change, proceed with normal update
 		await performAllocationUpdate(chargeId, newAllocation);
 	}
@@ -1336,6 +1363,36 @@
 		on:skip={handleSkipAutoAssociation}
 		on:close={closeAutoAssociationModal}
 	/>
+
+	<!-- Debug Controls -->
+	<div class="mb-4 p-4 bg-red-900 border border-red-700 rounded">
+		<h3 class="text-red-200 font-bold mb-2">Debug Controls</h3>
+		<button
+			class="px-3 py-2 bg-red-600 hover:bg-red-500 text-white text-sm rounded mr-2"
+			onclick={() => {
+				showAutoAssociationModal = true;
+				autoAssociationModalData = {
+					merchantName: 'Test Merchant',
+					currentAllocation: 'Test Budget',
+					newAllocation: 'New Budget',
+					autoAssociationBudget: 'Test Budget',
+					chargeId: 'test-123'
+				};
+			}}
+		>
+			Test Auto-Association Modal
+		</button>
+		<button
+			class="px-3 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm rounded"
+			onclick={() => {
+				console.log('Current modal state:', { showAutoAssociationModal, autoAssociationModalData });
+			}}
+		>
+			Log Modal State
+		</button>
+	</div>
+
+	<!-- Cycle Information -->
 </div>
 
 <!-- Fixed Footer with Running Totals -->


### PR DESCRIPTION
Add extensive debugging for auto-association popup.

This PR introduces comprehensive debugging to troubleshoot why the auto-association modal is not appearing when changing an allocation for a charge with an auto-association. It includes console logging, a visual debug display, a manual test button, and enhanced modal visibility to help identify if the condition is not met or if the modal has rendering/CSS issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-b43b9383-5ffc-4dd6-a136-a4f5fcf31683">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b43b9383-5ffc-4dd6-a136-a4f5fcf31683">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

