### PR TITLE
Debug allocation update request body error

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -355,7 +355,7 @@
 				headers: {
 					'Content-Type': 'application/json'
 				},
-				body: JSON.stringify(requestBody)
+				body: JSON.stringify({ allocated_to: newAllocation })
 			});
 
 			if (!response.ok) {


### PR DESCRIPTION
Fixes "Can't find variable: requestBody" error when updating charge allocations.

The `requestBody` variable was undefined in the `performAllocationUpdate` function, causing a runtime error. The fix correctly constructs the request body using the `newAllocation` parameter, which contains the value expected by the API.

---
<a href="https://cursor.com/background-agent?bcId=bc-e67553a6-2dc7-4bb4-81c2-8f4352dd0cfd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e67553a6-2dc7-4bb4-81c2-8f4352dd0cfd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

