### PR TITLE
Show amazon order identifier with merchant name

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -43,27 +43,31 @@
 		return `${month.toString().padStart(2, '0')}/${day.toString().padStart(2, '0')}`;
 	}
 
-	// Function to format merchant name with flight details
+	// Function to format merchant name with flight details and Amazon order ID
 	function formatMerchantName(charge) {
 		// Use normalized merchant name for consistent display
 		const merchantName = charge.merchant_normalized || charge.merchant;
 
-		if (!charge.flight_details) {
-			return merchantName;
+		// Check if this is an Amazon charge with order ID
+		if (charge.amazon_order_id) {
+			return `${merchantName} (${charge.amazon_order_id})`;
 		}
 
-		const flight = charge.flight_details;
-		const airports = [];
+		// Check for flight details
+		if (charge.flight_details) {
+			const flight = charge.flight_details;
+			const airports = [];
 
-		if (flight.departure_airport) {
-			airports.push(flight.departure_airport);
-		}
-		if (flight.arrival_airport) {
-			airports.push(flight.arrival_airport);
-		}
+			if (flight.departure_airport) {
+				airports.push(flight.departure_airport);
+			}
+			if (flight.arrival_airport) {
+				airports.push(flight.arrival_airport);
+			}
 
-		if (airports.length > 0) {
-			return `${merchantName} (${airports.join(', ')})`;
+			if (airports.length > 0) {
+				return `${merchantName} (${airports.join(', ')})`;
+			}
 		}
 
 		return merchantName;


### PR DESCRIPTION
Display Amazon order identifiers in brackets after the merchant name to help users identify specific Amazon charges.

---
<a href="https://cursor.com/background-agent?bcId=bc-405f0a25-8493-44c5-b53b-2008c3d8ea29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-405f0a25-8493-44c5-b53b-2008c3d8ea29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

