### PR TITLE
Fix missing order identifier in charge listing

### DIFF
--- a/webapp/debug-amazon-orders.js
+++ b/webapp/debug-amazon-orders.js
@@ -1,0 +1,47 @@
+import { extractAmazonOrderId } from './src/lib/server/amazon-orders-service.js';
+
+// Test cases for Amazon order ID extraction
+const testCases = [
+    'AMAZON.COM*123-4567890-1234567',
+    'AMZN.COM/BILL 987-6543210-9876543',
+    'Amazon.com 1234567890123456',
+    'AMAZON.COM*987-6543210-9876543',
+    'AMZN.COM/BILL 123-4567890-1234567',
+    'Amazon.com 9876543210987654',
+    'AMAZON.COM*111-2223333-4445555',
+    'AMZN.COM/BILL 555-6667777-8889999',
+    'Amazon.com 1111111111111111',
+    'AMAZON.COM*999-8887777-6665555',
+    'AMZN.COM/BILL 777-6665555-4443333',
+    'Amazon.com 9999999999999999'
+];
+
+console.log('Testing Amazon Order ID Extraction:');
+console.log('==================================');
+
+testCases.forEach((merchantString, index) => {
+    const orderId = extractAmazonOrderId(merchantString);
+    console.log(`${index + 1}. "${merchantString}"`);
+    console.log(`   Extracted Order ID: ${orderId || 'null'}`);
+    console.log('');
+});
+
+// Test edge cases
+console.log('Edge Cases:');
+console.log('===========');
+
+const edgeCases = [
+    'AMAZON.COM*123-4567890-1234567 EXTRA TEXT',
+    'AMZN.COM/BILL 987-6543210-9876543 (PENDING)',
+    'Amazon.com 1234567890123456 - Digital Purchase',
+    'AMAZON.COM*111-2223333-4445555*',
+    'AMZN.COM/BILL 555-6667777-8889999.',
+    'Amazon.com 9999999999999999!'
+];
+
+edgeCases.forEach((merchantString, index) => {
+    const orderId = extractAmazonOrderId(merchantString);
+    console.log(`${index + 1}. "${merchantString}"`);
+    console.log(`   Extracted Order ID: ${orderId || 'null'}`);
+    console.log('');
+});


### PR DESCRIPTION
Add a debug script to test Amazon order ID extraction.

This script helps diagnose why Amazon order identifiers are not displayed in the charge listing view by verifying the `extractAmazonOrderId` function's behavior with various merchant string formats.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a3f07f0-bc8a-48e8-99cf-f2ccb3d7ac2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a3f07f0-bc8a-48e8-99cf-f2ccb3d7ac2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

