### PR TITLE
Fix svelte build expression error

### DIFF
--- a/webapp/src/lib/components/HeatmapColumns.svelte
+++ b/webapp/src/lib/components/HeatmapColumns.svelte
@@ -53,7 +53,7 @@
 			}
 		}
 		
-		console.log('HeatmapColumns: Processed columns:', $inspect(columns));
+		console.log('HeatmapColumns: Processed columns:', columns);
 		
 		// Create tooltip element
 		tooltip = document.createElement('div');


### PR DESCRIPTION
Fixes build failure by replacing `$inspect` rune with direct variable logging in `console.log`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae036e11-1433-4d3b-8a1b-b0cb248d4033">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae036e11-1433-4d3b-8a1b-b0cb248d4033">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

