### PR TITLE
Fix mobile menu blur on expand

### DIFF
--- a/webapp/src/lib/components/MobileNavigation.svelte
+++ b/webapp/src/lib/components/MobileNavigation.svelte
@@ -46,7 +46,7 @@
 	<div
 		use:melt={$overlay}
 		transition:fade={{ duration: 300 }}
-		class="fixed inset-0 z-50 bg-base-800/40 backdrop-blur-sm transition-all duration-300"
+		class="fixed inset-0 z-50 bg-base-800/40 transition-all duration-300"
 	></div>
 
 	<div use:melt={$content}>


### PR DESCRIPTION
Remove `backdrop-blur-sm` from mobile navigation overlay to fix menu content blurring.

The `backdrop-blur-sm` class on the full-screen overlay was inadvertently blurring the mobile menu content itself, making it unreadable, instead of just blurring the background.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e9f035e-4557-4ca8-ba63-0132921c9c9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e9f035e-4557-4ca8-ba63-0132921c9c9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

