### PR TITLE
Fix main page menu scrolling

### DIFF
--- a/webapp/src/lib/components/DesktopNavigation.svelte
+++ b/webapp/src/lib/components/DesktopNavigation.svelte
@@ -17,7 +17,7 @@
 			animate-border"
 	>
 		{#each items as item (item)}
-			<DesktopNavigationItem href={`/#${item}`} isActive={active == item}
+			<DesktopNavigationItem href={`#${item}`} isActive={active == item}
 				>{item}</DesktopNavigationItem
 			>
 		{/each}

--- a/webapp/src/lib/components/MobileNavigationItem.svelte
+++ b/webapp/src/lib/components/MobileNavigationItem.svelte
@@ -4,7 +4,7 @@
 
 <li>
 	<a
-		href="/#{current}"
+		href="#{current}"
 		class="block py-2 {active == current ? 'text-green-400' : ''}"
 		onclick={() => {
 			hide();

--- a/webapp/src/routes/+page.svelte
+++ b/webapp/src/routes/+page.svelte
@@ -22,11 +22,30 @@
 
 				if (element) {
 					console.log(`Scrolling to element ${targetId} from ${source}`);
-					element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+					// Ensure the element is visible and scroll to it smoothly
+					element.scrollIntoView({ 
+						behavior: 'smooth', 
+						block: 'start',
+						inline: 'nearest'
+					});
 				} else {
 					console.log(`Element ${targetId} not found for scrolling from ${source}`);
 				}
 			}, 100); // 100ms
+		}
+	};
+
+	const handleHashClick = (event) => {
+		// Check if the clicked element is a hash link
+		const target = event.target.closest('a[href^="#"]');
+		if (target) {
+			const href = target.getAttribute('href');
+			if (href && href.startsWith('#')) {
+				event.preventDefault();
+				// Update the URL hash without triggering a page navigation
+				window.history.pushState(null, '', href);
+				scrollToHash(href, 'hashClick');
+			}
 		}
 	};
 
@@ -36,9 +55,22 @@
 		const module = await import('$lib/components/Background.svelte');
 		BackgroundComponent = module.default;
 
-		if (browser && typeof window !== 'undefined' && window.location.hash) {
-			scrollToHash(window.location.hash, 'onMount');
+		if (browser && typeof window !== 'undefined') {
+			// Add click event listener for hash links
+			document.addEventListener('click', handleHashClick);
+			
+			// Handle initial hash if present
+			if (window.location.hash) {
+				scrollToHash(window.location.hash, 'onMount');
+			}
 		}
+
+		// Cleanup function to remove event listener
+		return () => {
+			if (browser && typeof window !== 'undefined') {
+				document.removeEventListener('click', handleHashClick);
+			}
+		};
 	});
 
 	afterNavigate((navigation) => {


### PR DESCRIPTION
Fixes navigation menu items not scrolling to page sections by correcting link formats and adding a click handler for smooth in-page scrolling.

Previously, navigation links used `href="/#section"`, which triggered a full page navigation instead of an in-page scroll. This PR updates links to `href="#section"` and introduces a click event listener to handle these hash links, ensuring smooth scrolling to the target section without page reloads.

---
<a href="https://cursor.com/background-agent?bcId=bc-bbe4d94b-5f88-4e03-a304-96297237941b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bbe4d94b-5f88-4e03-a304-96297237941b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

