### PR TITLE
Fix orbit controls parent missing error

### DIFF
--- a/webapp/src/lib/components/Heatmap3D.svelte
+++ b/webapp/src/lib/components/Heatmap3D.svelte
@@ -182,16 +182,17 @@
 				position={[0, 20, 40]}
 				fov={60}
 				makeDefault
-			/>
-			<OrbitControls
-				enableDamping
-				dampingFactor={0.05}
-				enablePan={true}
-				enableZoom={true}
-				enableRotate={true}
-				autoRotate={true}
-				autoRotateSpeed={0.5}
-			/>
+			>
+				<OrbitControls
+					enableDamping
+					dampingFactor={0.05}
+					enablePan={true}
+					enableZoom={true}
+					enableRotate={true}
+					autoRotate={true}
+					autoRotateSpeed={0.5}
+				/>
+			</T.PerspectiveCamera>
 			
 			<!-- Simple test to verify Canvas is working -->
 			<T.Mesh position={[0, 0, 0]}>


### PR DESCRIPTION
Fixes 3D heatmap rendering error by nesting OrbitControls under the Camera component.

The `<OrbitControls>` component in Threlte/Three.js must be a direct child of a `<Camera>` component to function correctly and access camera properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-84d903b3-eab0-407e-ae4c-81f3e9eee342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84d903b3-eab0-407e-ae4c-81f3e9eee342">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

