### PR TITLE
Bump mermaid package to 11.10.0

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -53,7 +53,7 @@
 				"kolorist": "^1.8.0",
 				"magic-string": "^0.30.17",
 				"mdsvex": "^0.12.6",
-				"mermaid": "~> 11.10.0",
+				"mermaid": "11.10.0",
 				"miragejs": "^0.1.48",
 				"npm": "^11.5.2",
 				"playwright": "^1.54.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -54,7 +54,7 @@
 		"kolorist": "^1.8.0",
 		"magic-string": "^0.30.17",
 		"mdsvex": "^0.12.6",
-		"mermaid": "~> 11.10.0",
+		"mermaid": "11.10.0",
 		"miragejs": "^0.1.48",
 		"npm": "^11.5.2",
 		"playwright": "^1.54.2",


### PR DESCRIPTION
Pin mermaid package to exact version 11.10.0 to ensure a specific version is used.

---
<a href="https://cursor.com/background-agent?bcId=bc-18f23ddb-1afc-418d-ae9b-953c210bf11a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18f23ddb-1afc-418d-ae9b-953c210bf11a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

