### PR TITLE
Fix billing cycle display reactivity

### DIFF
--- a/webapp/src/routes/projects/ccbilling/new/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/new/+page.svelte
@@ -2,7 +2,7 @@
 	import Header from '$lib/components/Header.svelte';
 	import Footer from '$lib/components/Footer.svelte';
 	import Button from '$lib/components/Button.svelte';
-	import { goto } from '$app/navigation';
+	import { goto, invalidate } from '$app/navigation';
 
 	// Get default dates from server
 	const { data } = $props();
@@ -53,6 +53,9 @@
 				throw new Error(errorData.error || 'Failed to create billing cycle');
 			}
 
+			// Invalidate the billing cycles data cache to ensure fresh data is loaded
+			await invalidate('/projects/ccbilling');
+			
 			// Redirect to the main billing cycles page
 			await goto('/projects/ccbilling');
 		} catch (err) {


### PR DESCRIPTION
Add `invalidate()` call to refresh billing cycle data after creation, resolving a SvelteKit reactivity issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e5b6a8e-da48-49fa-9c27-8de010a082b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3e5b6a8e-da48-49fa-9c27-8de010a082b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

