### PR TITLE
Fix manifest icon download error

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -26,7 +26,10 @@
 		"lighthouse-dev": "lhci autorun --config=./.lighthouserc-dev.cjs",
 		"lighthouse-staging": "lhci autorun --config=./.lighthouserc.cjs",
 		"deploy": "npx wrangler deploy -e production",
-		"deploy-preview": "npx wrangler deploy --env preview"
+		"deploy-preview": "npx wrangler deploy --env preview",
+		"manifest:dev": "node scripts/generate-manifest.js development",
+		"manifest:preview": "node scripts/generate-manifest.js preview",
+		"manifest:production": "node scripts/generate-manifest.js production"
 	},
 	"devDependencies": {
 		"@cloudflare/vite-plugin": "^1.11.7",

--- a/webapp/scripts/generate-manifest.js
+++ b/webapp/scripts/generate-manifest.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+/**
+ * Script to generate environment-specific manifest files
+ * Run with: node scripts/generate-manifest.js [environment]
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const environments = {
+	development: {
+		baseUrl: 'http://localhost:5173',
+		outputFile: 'static/manifest-dev.json'
+	},
+	preview: {
+		baseUrl: 'https://ftn-preview.nick-brett1.workers.dev',
+		outputFile: 'static/manifest-preview.json'
+	},
+	production: {
+		baseUrl: 'https://fintechnick.com',
+		outputFile: 'static/manifest.json'
+	}
+};
+
+function generateManifest(env) {
+	const baseUrl = env.baseUrl;
+	
+	const manifest = {
+		name: "Fintech Nick",
+		display: "standalone",
+		icons: [
+			{ 
+				src: `${baseUrl}/icon-192.png`, 
+				type: "image/png", 
+				sizes: "192x192" 
+			},
+			{ 
+				src: `${baseUrl}/icon-512.png`, 
+				type: "image/png", 
+				sizes: "512x512" 
+			},
+			{
+				src: `${baseUrl}/icon-192-maskable.png`,
+				type: "image/png",
+				sizes: "192x192",
+				purpose: "maskable"
+			},
+			{
+				src: `${baseUrl}/icon-512-maskable.png`,
+				type: "image/png",
+				sizes: "512x512",
+				purpose: "maskable"
+			}
+		],
+		theme_color: "#FFFFFF",
+		background_color: "#FFFFFF",
+		start_url: "/",
+		scope: "/"
+	};
+	
+	return manifest;
+}
+
+function main() {
+	const envArg = process.argv[2] || 'production';
+	const env = environments[envArg];
+	
+	if (!env) {
+		console.error(`Unknown environment: ${envArg}`);
+		console.error(`Available environments: ${Object.keys(environments).join(', ')}`);
+		process.exit(1);
+	}
+	
+	console.log(`Generating manifest for ${envArg} environment...`);
+	console.log(`Base URL: ${env.baseUrl}`);
+	console.log(`Output file: ${env.outputFile}`);
+	
+	const manifest = generateManifest(env);
+	const outputPath = path.join(process.cwd(), env.outputFile);
+	
+	fs.writeFileSync(outputPath, JSON.stringify(manifest, null, '\t'));
+	console.log(`✅ Manifest generated successfully at ${env.outputFile}`);
+}
+
+main();

--- a/webapp/static/manifest.json
+++ b/webapp/static/manifest.json
@@ -2,16 +2,16 @@
 	"name": "Fintech Nick",
 	"display": "standalone",
 	"icons": [
-		{ "src": "/icon-192.png", "type": "image/png", "sizes": "192x192" },
-		{ "src": "/icon-512.png", "type": "image/png", "sizes": "512x512" },
+		{ "src": "https://fintechnick.com/icon-192.png", "type": "image/png", "sizes": "192x192" },
+		{ "src": "https://fintechnick.com/icon-512.png", "type": "image/png", "sizes": "512x512" },
 		{
-			"src": "/icon-192-maskable.png",
+			"src": "https://fintechnick.com/icon-192-maskable.png",
 			"type": "image/png",
 			"sizes": "192x192",
 			"purpose": "maskable"
 		},
 		{
-			"src": "/icon-512-maskable.png",
+			"src": "https://fintechnick.com/icon-512-maskable.png",
 			"type": "image/png",
 			"sizes": "512x512",
 			"purpose": "maskable"


### PR DESCRIPTION
Update `manifest.json` with absolute icon URLs and add a manifest generation script to fix PWA icon loading errors in production.

The PWA manifest was using relative paths for icons (e.g., `/icon-192.png`). While this works in development, in a production environment (e.g., `https://fintechnick.com`), the browser would attempt to fetch these icons from the root of the deployed domain. The "Download error or resource isn't a valid image" indicated that these icons were not accessible or correctly served from the expected production URLs. Changing to absolute URLs ensures the browser always fetches icons from the correct, specified location. The added script provides a flexible way to manage manifest URLs across different environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-de1c4805-fc28-411b-9743-5245fbfc2cf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de1c4805-fc28-411b-9743-5245fbfc2cf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

