### PR TITLE
Fix amazon order parsing and identifier

### DIFF
--- a/webapp/src/lib/server/amazon-orders-service.js
+++ b/webapp/src/lib/server/amazon-orders-service.js
@@ -23,6 +23,11 @@ export function extractAmazonOrderId(merchantString) {
 	let match = merchantString.match(standardPattern);
 	if (match) return match[1];
 
+	// Pattern for D01 format order IDs (D01-XXXXXXX-XXXXXXX)
+	const d01Pattern = /\b(D01-\d{7}-\d{7})\b/;
+	match = merchantString.match(d01Pattern);
+	if (match) return match[1];
+
 	// Pattern for compact order IDs (16 digits)
 	const compactPattern = /\b(\d{16})\b/;
 	match = merchantString.match(compactPattern);
@@ -61,6 +66,11 @@ export function extractAmazonOrderIdFromMultiLine(statementText) {
 		// Pattern for standard Amazon order IDs (XXX-XXXXXXX-XXXXXXX)
 		const standardPattern = /\b(\d{3}-\d{7}-\d{7})\b/;
 		let match = line.match(standardPattern);
+		if (match) return match[1];
+
+		// Pattern for D01 format order IDs (D01-XXXXXXX-XXXXXXX)
+		const d01Pattern = /\b(D01-\d{7}-\d{7})\b/;
+		match = line.match(d01Pattern);
 		if (match) return match[1];
 
 		// Pattern for compact order IDs (16 digits)

--- a/webapp/src/lib/utils/merchant-normalizer.js
+++ b/webapp/src/lib/utils/merchant-normalizer.js
@@ -179,7 +179,18 @@ function extractFlightDetails(merchant) {
 function extractAmazonDetails(merchant) {
 	const merchantUpper = merchant.toUpperCase();
 
-	// Check for specific Amazon services
+	// First check if this contains an order ID - if so, it's a purchase, not a service
+	const hasOrderId = /\b(\d{3}-\d{7}-\d{7})\b|\b(\d{16})\b|\b(\d{10,})\b/.test(merchant);
+	
+	// If it has an order ID, it's a purchase, not a service
+	if (hasOrderId) {
+		return {
+			merchant_normalized: 'AMAZON',
+			merchant_details: ''
+		};
+	}
+
+	// Check for specific Amazon services (only if no order ID found)
 	if (merchantUpper.includes('AMAZON PRIME')) {
 		return {
 			merchant_normalized: 'AMAZON PRIME',


### PR DESCRIPTION
Add support for D01-format Amazon order IDs and prioritize order ID extraction over "AMAZON PRIME" categorization to correctly parse Amazon transactions.

Previously, the `extractAmazonDetails` function would immediately categorize a transaction as 'AMAZON PRIME' if that string was present, preventing the extraction of an actual order ID from the merchant string or the full statement. This change ensures that if an order ID pattern is present, the transaction is categorized as 'AMAZON' (a purchase) and the ID is extracted, while still correctly categorizing true 'AMAZON PRIME' service charges. Additionally, a new D01-XXXXXXX-XXXXXXX order ID format is now recognized.

---
<a href="https://cursor.com/background-agent?bcId=bc-79f8ac59-f5d2-4c5e-b836-2cbbc59cfa4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79f8ac59-f5d2-4c5e-b836-2cbbc59cfa4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

