### PR TITLE
Add budget name tooltips to allocation icons

### DIFF
--- a/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/[id]/+page.svelte
@@ -1220,6 +1220,7 @@
 															? 'bg-blue-600 text-white'
 															: 'bg-gray-700 text-gray-300 hover:bg-gray-600'}"
 														data-allocation-tooltip={`Allocate to: ${budgetOption || 'Unallocated'}`}
+														title={`${budgetOption || 'Unallocated'}`}
 														onclick={() => updateChargeAllocation(charge.id, budgetOption)}
 													>
 														{getAllocationIcon(budgetOption, localData.budgets)}
@@ -1231,6 +1232,7 @@
 											<button
 												class="text-gray-500 hover:text-gray-300 transition-colors cursor-pointer"
 												data-allocation-tooltip={`Current: ${charge.allocated_to || 'Unallocated'}. Click to cycle through options.`}
+												title={`${charge.allocated_to || 'Unallocated'}`}
 												onclick={() =>
 													updateChargeAllocation(
 														charge.id,
@@ -1337,6 +1339,7 @@
 															? 'bg-blue-600 text-white'
 															: 'bg-gray-700 text-gray-300 hover:bg-gray-600'}"
 														data-allocation-tooltip={`Allocate to: ${budgetOption || 'Unallocated'}`}
+														title={`${budgetOption || 'Unallocated'}`}
 														onclick={() => updateChargeAllocation(charge.id, budgetOption)}
 													>
 														{getAllocationIcon(budgetOption, localData.budgets)}
@@ -1348,6 +1351,7 @@
 											<button
 												class="text-gray-500 hover:text-gray-300 transition-colors cursor-pointer"
 												data-allocation-tooltip={`Current: ${charge.allocated_to || 'Unallocated'}. Click to cycle through options.`}
+												title={`${charge.allocated_to || 'Unallocated'}`}
 												onclick={() =>
 													updateChargeAllocation(
 														charge.id,
@@ -1516,12 +1520,15 @@
 				<div class="flex flex-wrap items-center gap-4">
 					{#each getFilteredAllocationTotals() as [allocation, total]}
 						<div class="flex items-center gap-2">
-							<span class="text-lg"
-								>{getAllocationIcon(
+							<span 
+								class="text-lg cursor-help"
+								title={allocation === '__unallocated__' ? 'Unallocated' : allocation}
+							>
+								{getAllocationIcon(
 									allocation === '__unallocated__' ? null : allocation,
 									localData.budgets
-								)}</span
-							>
+								)}
+							</span>
 							<span class="text-gray-300 text-sm"
 								>{allocation === '__unallocated__' ? 'Unallocated' : allocation}:</span
 							>


### PR DESCRIPTION
Add tooltips to budget allocation icons on the charge listing page to display the budget name on hover, improving clarity for users.

---
<a href="https://cursor.com/background-agent?bcId=bc-823bd5b3-5b9b-41e7-83f2-d46618c682e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-823bd5b3-5b9b-41e7-83f2-d46618c682e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

