### PR TITLE
Add fireworks for zero unallocated charges

### DIFF
--- a/webapp/FIREWORKS_FEATURE.md
+++ b/webapp/FIREWORKS_FEATURE.md
@@ -1,0 +1,68 @@
+# Fireworks Feature
+
+## Overview
+The fireworks feature automatically displays a celebratory particle animation whenever the unallocated charges in the billing cycle reach zero dollars.
+
+## How It Works
+
+### Trigger Condition
+- **When**: Unallocated charges total changes from a positive value to exactly $0.00
+- **Where**: In the `getFilteredAllocationTotals()` function in the billing cycle page
+- **How**: Monitors the `lastUnallocatedTotal` vs current unallocated total
+
+### Fireworks Display
+- **Duration**: 3 seconds
+- **Effect**: Colorful particle animation covering the full screen
+- **Colors**: Red, green, blue, yellow, magenta, cyan
+- **Particles**: 150 animated particles with random sizes and movements
+
+### Technical Implementation
+
+#### Components
+- **Fireworks.svelte**: Reusable fireworks component using tsParticles
+- **Main Page**: Integrated into `[id]/+page.svelte` billing cycle page
+
+#### State Management
+```javascript
+// Fireworks state
+let showFireworks = $state(false);
+let lastUnallocatedTotal = $state(0);
+```
+
+#### Trigger Logic
+```javascript
+// Check if unallocated charges reached zero and trigger fireworks
+const unallocatedTotal = totals['__unallocated__'] || 0;
+if (unallocatedTotal === 0 && lastUnallocatedTotal > 0) {
+    showFireworks = true;
+    // Hide fireworks after 3 seconds
+    setTimeout(() => {
+        showFireworks = false;
+    }, 3000);
+}
+lastUnallocatedTotal = unallocatedTotal;
+```
+
+## Dependencies
+- `@tsparticles/engine`: Core particle engine
+- `@tsparticles/slim`: Lightweight particle system
+- `@tsparticles/shape-text`: Text shape support
+
+## Usage
+The fireworks automatically trigger when:
+1. User allocates all unallocated charges to budgets
+2. User deletes charges that were previously unallocated
+3. Any action that reduces unallocated charges to zero
+
+## Customization
+To modify the fireworks effect:
+- Edit `webapp/src/lib/components/Fireworks.svelte`
+- Adjust particle count, colors, speed, and animation parameters
+- Change display duration in the main page logic
+
+## Testing
+To test the fireworks:
+1. Navigate to a billing cycle with unallocated charges
+2. Allocate charges until unallocated total reaches $0.00
+3. Watch for the fireworks animation
+4. Check browser console for debug messages

--- a/webapp/src/lib/components/Fireworks.svelte
+++ b/webapp/src/lib/components/Fireworks.svelte
@@ -1,0 +1,119 @@
+<script>
+	import { onMount, onDestroy } from 'svelte';
+	import { tsParticles } from '@tsparticles/engine';
+	import { loadSlim } from '@tsparticles/slim';
+	import { loadTextShape } from '@tsparticles/shape-text';
+
+	export let show = false;
+	export let containerId = 'fireworks-container';
+
+	let container;
+	let particlesInitialized = false;
+
+	onMount(async () => {
+		await loadSlim(tsParticles);
+		await loadTextShape(tsParticles);
+		particlesInitialized = true;
+	});
+
+	async function startFireworks() {
+		if (!particlesInitialized || !container) return;
+
+		await tsParticles.load({
+			id: containerId,
+			element: container,
+			options: {
+				fpsLimit: 60,
+				particles: {
+					number: {
+						value: 150,
+						density: {
+							enable: true,
+							value_area: 800
+						}
+					},
+					color: {
+						value: ['#ff0000', '#00ff00', '#0000ff', '#ffff00', '#ff00ff', '#00ffff']
+					},
+					shape: {
+						type: 'circle'
+					},
+					opacity: {
+						value: 1,
+						random: false,
+						anim: {
+							enable: true,
+							speed: 1,
+							opacity_min: 0,
+							sync: false
+						}
+					},
+					size: {
+						value: 3,
+						random: true,
+						anim: {
+							enable: true,
+							speed: 2,
+							size_min: 0.3,
+							sync: false
+						}
+					},
+					line_linked: {
+						enable: false
+					},
+					move: {
+						enable: true,
+						speed: 6,
+						direction: 'none',
+						random: false,
+						straight: false,
+						out_mode: 'out',
+						bounce: false,
+						attract: {
+							enable: false,
+							rotateX: 600,
+							rotateY: 1200
+						}
+					}
+				},
+				interactivity: {
+					detect_on: 'canvas',
+					events: {
+						onclick: {
+							enable: true,
+							mode: 'repulse'
+						},
+						onresize: true
+					},
+					modes: {
+						repulse: {
+							distance: 100,
+							duration: 0.4
+						}
+					}
+				},
+				retina_detect: true
+			}
+		});
+	}
+
+
+
+	$: if (show && particlesInitialized) {
+		console.log('🎆 Starting fireworks display!');
+		startFireworks();
+	}
+
+	onDestroy(() => {
+		if (container) {
+			tsParticles.destroy(container);
+		}
+	});
+</script>
+
+<div
+	bind:this={container}
+	{containerId}
+	class="fixed inset-0 pointer-events-none z-50"
+	style="display: {show ? 'block' : 'none'}"
+></div>


### PR DESCRIPTION
Add a particle fireworks display to celebrate when unallocated charges reach zero dollars.

---
<a href="https://cursor.com/background-agent?bcId=bc-993764fd-3fad-4aa5-acae-96b40d864a44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-993764fd-3fad-4aa5-acae-96b40d864a44">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

