### PR TITLE
Add total row to billing cycles

### DIFF
--- a/webapp/src/routes/projects/ccbilling/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/+page.svelte
@@ -42,6 +42,12 @@
 		});
 		return entries;
 	}
+
+	function getCycleTotalAmount(cycleId) {
+		// Calculate the sum of all allocations for this cycle
+		const totals = getTotalsForCycle(cycleId);
+		return totals.reduce((sum, [, amount]) => sum + amount, 0);
+	}
 </script>
 
 <Header />
@@ -82,6 +88,12 @@
 												<span class="text-white tabular-nums">{formatCurrency(total)}</span>
 											</div>
 										{/each}
+										{#if getTotalsForCycle(cycle.id).length > 0}
+											<div class="flex justify-between gap-4 pt-2 mt-2 border-t border-gray-600">
+												<span class="text-gray-200 font-medium">Total</span>
+												<span class="text-white font-semibold tabular-nums">{formatCurrency(getCycleTotalAmount(cycle.id))}</span>
+											</div>
+										{/if}
 									</div>
 								</div>
 								<div class="text-gray-400">


### PR DESCRIPTION
Add a total row to the billing cycles listing to display the sum of all budget allocations for each cycle.

---
<a href="https://cursor.com/background-agent?bcId=bc-49e6d873-7c61-4c78-a11e-138b72f46464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49e6d873-7c61-4c78-a11e-138b72f46464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

