### PR TITLE
Fix merchant assignment case sensitivity

### DIFF
--- a/webapp/src/lib/server/ccbilling-db.js
+++ b/webapp/src/lib/server/ccbilling-db.js
@@ -197,11 +197,15 @@ export async function deleteBudget(event, id) {
 export async function addBudgetMerchant(event, budget_id, merchant_normalized) {
 	const db = event.platform?.env?.CCBILLING_DB;
 	if (!db) throw new Error('CCBILLING_DB binding not found');
+	
+	// Normalize the merchant name to ensure case-insensitive matching
+	const normalized = normalizeMerchant(merchant_normalized);
+	
 	await db
 		.prepare(
 			'INSERT INTO budget_merchant (budget_id, merchant_normalized, merchant) VALUES (?, ?, ?)'
 		)
-		.bind(budget_id, merchant_normalized, merchant_normalized)
+		.bind(budget_id, normalized.merchant_normalized, normalized.merchant_normalized)
 		.run();
 }
 
@@ -214,9 +218,13 @@ export async function addBudgetMerchant(event, budget_id, merchant_normalized) {
 export async function removeBudgetMerchant(event, budget_id, merchant_normalized) {
 	const db = event.platform?.env?.CCBILLING_DB;
 	if (!db) throw new Error('CCBILLING_DB binding not found');
+	
+	// Normalize the merchant name to ensure case-insensitive matching
+	const normalized = normalizeMerchant(merchant_normalized);
+	
 	await db
 		.prepare('DELETE FROM budget_merchant WHERE budget_id = ? AND merchant_normalized = ?')
-		.bind(budget_id, merchant_normalized)
+		.bind(budget_id, normalized.merchant_normalized)
 		.run();
 }
 
@@ -642,6 +650,10 @@ export async function getUnassignedMerchants(event) {
 export async function getBudgetByMerchant(event, merchant_normalized) {
 	const db = event.platform?.env?.CCBILLING_DB;
 	if (!db) throw new Error('CCBILLING_DB binding not found');
+	
+	// Normalize the merchant name to ensure case-insensitive matching
+	const normalized = normalizeMerchant(merchant_normalized);
+	
 	const result = await db
 		.prepare(
 			`
@@ -651,7 +663,7 @@ export async function getBudgetByMerchant(event, merchant_normalized) {
             WHERE bm.merchant_normalized = ?
         `
 		)
-		.bind(merchant_normalized)
+		.bind(normalized.merchant_normalized)
 		.first();
 	return result || null;
 }

--- a/webapp/src/lib/server/ccbilling-db.test.js
+++ b/webapp/src/lib/server/ccbilling-db.test.js
@@ -270,7 +270,7 @@ describe('ccbilling-db functions', () => {
 				expect(mockDb.prepare).toHaveBeenCalledWith(
 					'INSERT INTO budget_merchant (budget_id, merchant_normalized, merchant) VALUES (?, ?, ?)'
 				);
-				expect(mockDb.bind).toHaveBeenCalledWith(1, 'Amazon', 'Amazon');
+				expect(mockDb.bind).toHaveBeenCalledWith(1, 'AMAZON', 'AMAZON');
 				expect(mockDb.run).toHaveBeenCalled();
 			});
 		});
@@ -284,7 +284,7 @@ describe('ccbilling-db functions', () => {
 				expect(mockDb.prepare).toHaveBeenCalledWith(
 					'DELETE FROM budget_merchant WHERE budget_id = ? AND merchant_normalized = ?'
 				);
-				expect(mockDb.bind).toHaveBeenCalledWith(1, 'Amazon');
+				expect(mockDb.bind).toHaveBeenCalledWith(1, 'AMAZON');
 				expect(mockDb.run).toHaveBeenCalled();
 			});
 		});

--- a/webapp/src/lib/utils/merchant-normalizer.js
+++ b/webapp/src/lib/utils/merchant-normalizer.js
@@ -370,5 +370,6 @@ function normalizeGenericMerchant(merchant) {
 	normalized = normalized.replace(/\s+[A-Z]{2}\s*$/i, ''); // Remove state codes
 	normalized = normalized.replace(/\s+\d{5}\s*$/i, ''); // Remove ZIP codes
 
-	return normalized;
+	// Convert to uppercase to ensure case-insensitive matching
+	return normalized.toUpperCase();
 }


### PR DESCRIPTION
Normalize merchant names to uppercase for all database operations to fix case-sensitivity issues in merchant allocation.

The system previously had inconsistent case handling: frontend filtering used `toLowerCase()`, database storage used normalized (uppercase) names, but backend assignment functions did not normalize input merchant names before comparison. This resulted in "Refund Globalblue.com Stockholm" and "REFUND GLOBALBLUE.COM STOCKHOLM" being treated as distinct, causing incorrect unassigned lists and assignment errors. This PR ensures all relevant merchant names are consistently normalized to uppercase.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddd1ae1c-63cb-473e-aeb0-d3708232c9c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddd1ae1c-63cb-473e-aeb0-d3708232c9c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

