### PR TITLE
Merge duplicate merchants by case

### DIFF
--- a/webapp/MERCHANT_DEDUPLICATION.md
+++ b/webapp/MERCHANT_DEDUPLICATION.md
@@ -1,0 +1,146 @@
+# Merchant Deduplication Feature
+
+## Overview
+
+The merchant deduplication feature addresses the problem of duplicate merchants that only differ in case (e.g., "AMAZON" vs "amazon" vs "Amazon"). This ensures consistency across the credit card billing system.
+
+## How It Works
+
+### 1. Detection
+
+- Scans all `merchant_normalized` values from both `payment` and `budget_merchant` tables
+- Groups merchants by their uppercase form to identify case-only duplicates
+- Counts usage of each variant to provide detailed analysis
+
+### 2. Canonical Form Selection
+
+The system chooses a canonical form using this priority:
+
+1. **Uppercase versions** are preferred (e.g., "AMAZON" over "amazon")
+2. **Alphabetical order** as a tiebreaker if multiple uppercase versions exist
+
+### 3. Deduplication Process
+
+- **Payment records**: Updates all non-canonical variants to use the canonical form
+- **Budget assignments**: Handles conflicts intelligently:
+  - If a budget already has the canonical form, removes duplicate assignments
+  - If a budget doesn't have the canonical form, updates the variant to canonical
+  - Prevents duplicate budget-merchant relationships
+
+## API Endpoints
+
+### GET `/api/admin/deduplicate-merchants`
+
+Returns analysis of duplicate merchants without making changes.
+
+**Response:**
+
+```json
+{
+	"duplicatesFound": 3,
+	"totalVariants": 8,
+	"totalPaymentsAffected": 150,
+	"totalBudgetMerchantsAffected": 5,
+	"duplicates": [
+		{
+			"canonicalForm": "AMAZON",
+			"canonical": "AMAZON",
+			"variants": [
+				{
+					"variant": "AMAZON",
+					"paymentCount": 100,
+					"budgetCount": 1,
+					"isCanonical": true
+				},
+				{
+					"variant": "amazon",
+					"paymentCount": 30,
+					"budgetCount": 0,
+					"isCanonical": false
+				}
+			],
+			"totalVariants": 2
+		}
+	]
+}
+```
+
+### POST `/api/admin/deduplicate-merchants`
+
+Performs the actual deduplication.
+
+**Request:**
+
+```json
+{
+	"dryRun": false // Set to true for preview mode (default: true)
+}
+```
+
+**Response:**
+
+```json
+{
+	"success": true,
+	"dryRun": false,
+	"duplicatesProcessed": 3,
+	"paymentsUpdated": 50,
+	"budgetMerchantsUpdated": 2,
+	"budgetMerchantsRemoved": 3,
+	"errors": []
+}
+```
+
+## Admin Interface
+
+The deduplication feature is accessible through the Admin Tools page at `/projects/ccbilling/admin`. The interface provides:
+
+1. **Analysis Preview**: Shows duplicate groups and their impact
+2. **Refresh Analysis**: Updates the duplicate detection
+3. **Run Deduplication**: Performs the actual merge operation
+
+## Safety Features
+
+- **Authentication Required**: Only authenticated admin users can access
+- **Dry Run Default**: POST requests default to dry run mode
+- **Transaction Safety**: Updates are performed in logical groups
+- **Error Handling**: Graceful handling of database errors
+- **Conflict Resolution**: Smart handling of budget assignment conflicts
+
+## Use Cases
+
+### Example Scenario
+
+You have these merchants in your system:
+
+- "AMAZON" (100 payments, assigned to "Shopping" budget)
+- "amazon" (30 payments, not assigned)
+- "Amazon" (20 payments, assigned to "Shopping" budget - duplicate!)
+
+**After deduplication:**
+
+- All 150 payments use "AMAZON" as merchant_normalized
+- Only one "AMAZON" → "Shopping" budget assignment remains
+- Data consistency is restored
+
+## Integration
+
+The deduplication works alongside the existing merchant normalization system:
+
+1. Run normalization first to ensure consistent `merchant_normalized` values
+2. Run deduplication to merge case-only duplicates
+3. Both processes can be run from the same admin interface
+
+## Database Impact
+
+The feature modifies:
+
+- `payment.merchant_normalized` - Updates to canonical forms
+- `budget_merchant.merchant_normalized` - Updates to canonical forms
+- `budget_merchant` records - Removes true duplicates
+
+No changes are made to:
+
+- Original merchant names (`payment.merchant`)
+- Budget names or IDs
+- Payment amounts or dates

--- a/webapp/src/routes/api/admin/deduplicate-merchants/+server.js
+++ b/webapp/src/routes/api/admin/deduplicate-merchants/+server.js
@@ -1,0 +1,274 @@
+import { json } from '@sveltejs/kit';
+import { requireUser } from '$lib/server/require-user.js';
+
+/**
+ * Admin endpoint to deduplicate merchants that only differ in case
+ * This identifies merchants that are identical when compared case-insensitively
+ * and merges them to use a consistent canonical form.
+ */
+export async function POST(event) {
+	// Require authentication
+	const authResult = await requireUser(event);
+	if (authResult instanceof Response) return authResult;
+
+	const db = event.platform?.env?.CCBILLING_DB;
+	if (!db) {
+		return json({ error: 'Database not available' }, { status: 500 });
+	}
+
+	try {
+		const body = await event.request.json().catch(() => ({}));
+		const dryRun = body.dryRun !== false; // Default to dry run unless explicitly disabled
+
+		// Find all duplicate merchants that only differ in case
+		const duplicates = await findCaseDuplicates(db);
+
+		if (dryRun) {
+			return json({
+				success: true,
+				dryRun: true,
+				duplicatesFound: duplicates.length,
+				duplicates: duplicates,
+				message: `Found ${duplicates.length} groups of case-only duplicate merchants. Set dryRun: false to perform the deduplication.`
+			});
+		}
+
+		// Perform the actual deduplication
+		const results = await deduplicateMerchants(db, duplicates);
+
+		return json({
+			success: true,
+			dryRun: false,
+			duplicatesProcessed: duplicates.length,
+			paymentsUpdated: results.paymentsUpdated,
+			budgetMerchantsUpdated: results.budgetMerchantsUpdated,
+			budgetMerchantsRemoved: results.budgetMerchantsRemoved,
+			errors: results.errors.length > 0 ? results.errors : undefined,
+			message: `Successfully deduplicated ${duplicates.length} merchant groups.`
+		});
+	} catch (error) {
+		console.error('Merchant deduplication failed:', error);
+		return json(
+			{
+				error: 'Failed to deduplicate merchants',
+				details: error.message
+			},
+			{ status: 500 }
+		);
+	}
+}
+
+/**
+ * Find merchants that are duplicates when compared case-insensitively
+ */
+async function findCaseDuplicates(db) {
+	// Find all unique merchant_normalized values that have case variations
+	const { results: potentialDuplicates } = await db
+		.prepare(
+			`
+			SELECT 
+				UPPER(merchant_normalized) as canonical_form,
+				GROUP_CONCAT(DISTINCT merchant_normalized) as variants,
+				COUNT(DISTINCT merchant_normalized) as variant_count
+			FROM (
+				-- Get all merchant_normalized values from payments
+				SELECT DISTINCT merchant_normalized
+				FROM payment 
+				WHERE merchant_normalized IS NOT NULL
+				UNION
+				-- Get all merchant_normalized values from budget_merchant
+				SELECT DISTINCT merchant_normalized
+				FROM budget_merchant 
+				WHERE merchant_normalized IS NOT NULL
+			)
+			GROUP BY UPPER(merchant_normalized)
+			HAVING variant_count > 1
+			ORDER BY variant_count DESC, canonical_form
+		`
+		)
+		.all();
+
+	// Process each group of duplicates
+	const duplicates = [];
+	for (const group of potentialDuplicates) {
+		const variants = group.variants.split(',');
+
+		// Choose the canonical form (prefer uppercase, then alphabetical)
+		const canonical = variants.sort((a, b) => {
+			// Prefer uppercase versions
+			const aIsUpper = a === a.toUpperCase();
+			const bIsUpper = b === b.toUpperCase();
+			if (aIsUpper && !bIsUpper) return -1;
+			if (!aIsUpper && bIsUpper) return 1;
+			// If both are same case, sort alphabetically
+			return a.localeCompare(b);
+		})[0];
+
+		// Get usage counts for each variant
+		const variantDetails = [];
+		for (const variant of variants) {
+			const paymentCount = await db
+				.prepare('SELECT COUNT(*) as count FROM payment WHERE merchant_normalized = ?')
+				.bind(variant)
+				.first();
+
+			const budgetCount = await db
+				.prepare('SELECT COUNT(*) as count FROM budget_merchant WHERE merchant_normalized = ?')
+				.bind(variant)
+				.first();
+
+			variantDetails.push({
+				variant,
+				paymentCount: paymentCount.count,
+				budgetCount: budgetCount.count,
+				isCanonical: variant === canonical
+			});
+		}
+
+		duplicates.push({
+			canonicalForm: group.canonical_form,
+			canonical,
+			variants: variantDetails,
+			totalVariants: variants.length
+		});
+	}
+
+	return duplicates;
+}
+
+/**
+ * Perform the actual deduplication by updating all records to use canonical forms
+ */
+async function deduplicateMerchants(db, duplicates) {
+	let paymentsUpdated = 0;
+	let budgetMerchantsUpdated = 0;
+	let budgetMerchantsRemoved = 0;
+	const errors = [];
+
+	for (const duplicateGroup of duplicates) {
+		const canonical = duplicateGroup.canonical;
+		const nonCanonicalVariants = duplicateGroup.variants
+			.filter((v) => !v.isCanonical)
+			.map((v) => v.variant);
+
+		try {
+			// Update payments to use canonical form
+			for (const variant of nonCanonicalVariants) {
+				const result = await db
+					.prepare('UPDATE payment SET merchant_normalized = ? WHERE merchant_normalized = ?')
+					.bind(canonical, variant)
+					.run();
+				paymentsUpdated += result.changes || 0;
+			}
+
+			// Handle budget_merchant duplicates more carefully
+			// First, get all budget assignments for the canonical form
+			const { results: existingBudgets } = await db
+				.prepare('SELECT DISTINCT budget_id FROM budget_merchant WHERE merchant_normalized = ?')
+				.bind(canonical)
+				.all();
+
+			const existingBudgetIds = new Set(existingBudgets.map((b) => b.budget_id));
+
+			// For each non-canonical variant
+			for (const variant of nonCanonicalVariants) {
+				// Get budget assignments for this variant
+				const { results: variantBudgets } = await db
+					.prepare('SELECT budget_id FROM budget_merchant WHERE merchant_normalized = ?')
+					.bind(variant)
+					.all();
+
+				for (const budget of variantBudgets) {
+					if (existingBudgetIds.has(budget.budget_id)) {
+						// Budget already has canonical form, just remove the variant
+						await db
+							.prepare(
+								'DELETE FROM budget_merchant WHERE merchant_normalized = ? AND budget_id = ?'
+							)
+							.bind(variant, budget.budget_id)
+							.run();
+						budgetMerchantsRemoved++;
+					} else {
+						// Update the variant to canonical form
+						await db
+							.prepare(
+								'UPDATE budget_merchant SET merchant_normalized = ? WHERE merchant_normalized = ? AND budget_id = ?'
+							)
+							.bind(canonical, variant, budget.budget_id)
+							.run();
+						budgetMerchantsUpdated++;
+						existingBudgetIds.add(budget.budget_id);
+					}
+				}
+			}
+		} catch (error) {
+			errors.push({
+				canonicalForm: duplicateGroup.canonicalForm,
+				canonical,
+				variants: nonCanonicalVariants,
+				error: error.message
+			});
+		}
+	}
+
+	return {
+		paymentsUpdated,
+		budgetMerchantsUpdated,
+		budgetMerchantsRemoved,
+		errors
+	};
+}
+
+/**
+ * Get deduplication status and preview
+ */
+export async function GET(event) {
+	// Require authentication
+	const authResult = await requireUser(event);
+	if (authResult instanceof Response) return authResult;
+
+	const db = event.platform?.env?.CCBILLING_DB;
+	if (!db) {
+		return json({ error: 'Database not available' }, { status: 500 });
+	}
+
+	try {
+		// Find case duplicates for preview
+		const duplicates = await findCaseDuplicates(db);
+
+		// Get summary statistics
+		const totalVariants = duplicates.reduce((sum, group) => sum + group.totalVariants, 0);
+		const totalGroups = duplicates.length;
+		const totalPaymentsAffected = duplicates.reduce(
+			(sum, group) =>
+				sum + group.variants.reduce((variantSum, variant) => variantSum + variant.paymentCount, 0),
+			0
+		);
+		const totalBudgetMerchantsAffected = duplicates.reduce(
+			(sum, group) =>
+				sum + group.variants.reduce((variantSum, variant) => variantSum + variant.budgetCount, 0),
+			0
+		);
+
+		return json({
+			duplicatesFound: totalGroups,
+			totalVariants,
+			totalPaymentsAffected,
+			totalBudgetMerchantsAffected,
+			duplicates: duplicates.slice(0, 10), // Show first 10 for preview
+			message:
+				totalGroups === 0
+					? 'No case-only duplicate merchants found!'
+					: `Found ${totalGroups} groups of merchants with case-only differences affecting ${totalPaymentsAffected} payments and ${totalBudgetMerchantsAffected} budget assignments.`
+		});
+	} catch (error) {
+		console.error('Failed to get deduplication status:', error);
+		return json(
+			{
+				error: 'Failed to get deduplication status',
+				details: error.message
+			},
+			{ status: 500 }
+		);
+	}
+}

--- a/webapp/src/routes/projects/ccbilling/admin/+page.svelte
+++ b/webapp/src/routes/projects/ccbilling/admin/+page.svelte
@@ -7,6 +7,11 @@
 	let results = null;
 	let error = null;
 
+	let deduplicating = false;
+	let dedupeResults = null;
+	let dedupeError = null;
+	let dedupePreview = null;
+
 	async function runNormalization() {
 		normalizing = true;
 		error = null;
@@ -30,6 +35,53 @@
 			normalizing = false;
 		}
 	}
+
+	async function loadDedupePreview() {
+		dedupeError = null;
+		dedupePreview = null;
+
+		try {
+			const response = await fetch('/api/admin/deduplicate-merchants');
+			if (!response.ok) {
+				throw new Error(`HTTP error! status: ${response.status}`);
+			}
+			dedupePreview = await response.json();
+		} catch (err) {
+			dedupeError = err.message;
+		}
+	}
+
+	async function runDeduplication() {
+		deduplicating = true;
+		dedupeError = null;
+		dedupeResults = null;
+
+		try {
+			const response = await fetch('/api/admin/deduplicate-merchants', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ dryRun: false })
+			});
+
+			if (!response.ok) {
+				throw new Error(`HTTP error! status: ${response.status}`);
+			}
+
+			dedupeResults = await response.json();
+			// Refresh preview after deduplication
+			loadDedupePreview();
+		} catch (err) {
+			dedupeError = err.message;
+		} finally {
+			deduplicating = false;
+		}
+	}
+
+	// Load preview on component mount
+	import { onMount } from 'svelte';
+	onMount(() => {
+		loadDedupePreview();
+	});
 </script>
 
 <svelte:head>
@@ -42,23 +94,22 @@
 	<div class="max-w-4xl mx-auto">
 		<div class="flex items-center justify-between mb-8">
 			<h1 class="text-3xl font-bold">Admin Tools</h1>
-			<Button href="/projects/ccbilling" variant="secondary" size="lg">Back to Billing Cycles</Button>
+			<Button href="/projects/ccbilling" variant="secondary" size="lg"
+				>Back to Billing Cycles</Button
+			>
 		</div>
 
 		<!-- Database Normalization Section -->
 		<div class="bg-gray-800 border border-gray-700 rounded-lg p-6">
 			<h2 class="text-xl font-semibold mb-4">Database Normalization</h2>
-			
+
 			<p class="text-gray-300 mb-6">
-				Run the merchant normalization process across all payment records and budget-to-merchant auto-association mappings. This will ensure all merchant names are consistently normalized and budget assignments stay in sync.
+				Run the merchant normalization process across all payment records and budget-to-merchant
+				auto-association mappings. This will ensure all merchant names are consistently normalized
+				and budget assignments stay in sync.
 			</p>
 
-			<Button 
-				onclick={runNormalization} 
-				variant="success" 
-				size="lg"
-				disabled={normalizing}
-			>
+			<Button onclick={runNormalization} variant="success" size="lg" disabled={normalizing}>
 				{normalizing ? 'Running...' : 'Run Normalization'}
 			</Button>
 
@@ -77,15 +128,112 @@
 
 			{#if results}
 				<div class="mt-6 p-4 bg-green-900 border border-green-700 rounded-lg">
-					<div class="text-green-300">
-						✅ Normalization completed successfully!
-					</div>
+					<div class="text-green-300">✅ Normalization completed successfully!</div>
 					<div class="mt-3 text-sm text-green-200">
 						<div>Payments updated: {results.paymentsUpdated}</div>
-						<div>Budget to merchant auto-association mappings updated: {results.budgetMerchantsUpdated || 0}</div>
+						<div>
+							Budget to merchant auto-association mappings updated: {results.budgetMerchantsUpdated ||
+								0}
+						</div>
 						{#if results.errors && results.errors.length > 0}
 							<div class="mt-2 text-yellow-200">
 								Warnings: {results.errors.length} issues encountered
+							</div>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Merchant Deduplication Section -->
+		<div class="bg-gray-800 border border-gray-700 rounded-lg p-6 mt-8">
+			<h2 class="text-xl font-semibold mb-4">Merchant Deduplication</h2>
+
+			<p class="text-gray-300 mb-6">
+				Find and merge merchants that are identical except for case differences (e.g., "AMAZON" and
+				"amazon"). This ensures consistent merchant names throughout the system.
+			</p>
+
+			{#if dedupePreview}
+				<div class="mb-6 p-4 bg-gray-700 border border-gray-600 rounded-lg">
+					<h3 class="text-lg font-medium mb-3">Duplicate Analysis</h3>
+
+					{#if dedupePreview.duplicatesFound === 0}
+						<div class="text-green-300">
+							✅ No case-only duplicate merchants found! Your merchant data is clean.
+						</div>
+					{:else}
+						<div class="text-yellow-300 mb-4">
+							⚠️ Found {dedupePreview.duplicatesFound} groups of duplicate merchants affecting:
+							<ul class="list-disc list-inside mt-2 text-sm">
+								<li>{dedupePreview.totalPaymentsAffected} payment records</li>
+								<li>{dedupePreview.totalBudgetMerchantsAffected} budget assignments</li>
+							</ul>
+						</div>
+
+						{#if dedupePreview.duplicates && dedupePreview.duplicates.length > 0}
+							<div class="text-sm">
+								<h4 class="font-medium mb-2">Examples of duplicates (showing first 5):</h4>
+								{#each dedupePreview.duplicates.slice(0, 5) as duplicate}
+									<div class="mb-2 p-2 bg-gray-600 rounded">
+										<div class="font-medium text-blue-300">{duplicate.canonicalForm}</div>
+										<div class="text-xs text-gray-300">
+											Will merge: {duplicate.variants.map((v) => v.variant).join(', ')}
+											→ <span class="text-green-300">{duplicate.canonical}</span>
+										</div>
+										<div class="text-xs text-gray-400">
+											Total usage: {duplicate.variants.reduce(
+												(sum, v) => sum + v.paymentCount + v.budgetCount,
+												0
+											)} records
+										</div>
+									</div>
+								{/each}
+								{#if dedupePreview.duplicates.length > 5}
+									<div class="text-xs text-gray-400">
+										... and {dedupePreview.duplicates.length - 5} more groups
+									</div>
+								{/if}
+							</div>
+						{/if}
+					{/if}
+				</div>
+			{/if}
+
+			<div class="flex gap-4">
+				<Button onclick={loadDedupePreview} variant="secondary" size="lg">Refresh Analysis</Button>
+
+				{#if dedupePreview && dedupePreview.duplicatesFound > 0}
+					<Button onclick={runDeduplication} variant="warning" size="lg" disabled={deduplicating}>
+						{deduplicating ? 'Deduplicating...' : 'Run Deduplication'}
+					</Button>
+				{/if}
+			</div>
+
+			{#if dedupeError}
+				<div class="mt-6 p-4 bg-red-900 border border-red-700 rounded-lg">
+					<div class="text-red-300">
+						❌ Error: {dedupeError}
+						{#if dedupeError.includes('401')}
+							<div class="mt-2 text-red-200 text-sm">
+								This appears to be an authentication error. You may need to log in again.
+							</div>
+						{/if}
+					</div>
+				</div>
+			{/if}
+
+			{#if dedupeResults}
+				<div class="mt-6 p-4 bg-green-900 border border-green-700 rounded-lg">
+					<div class="text-green-300">✅ Deduplication completed successfully!</div>
+					<div class="mt-3 text-sm text-green-200">
+						<div>Merchant groups processed: {dedupeResults.duplicatesProcessed}</div>
+						<div>Payment records updated: {dedupeResults.paymentsUpdated}</div>
+						<div>Budget assignments updated: {dedupeResults.budgetMerchantsUpdated}</div>
+						<div>Duplicate budget assignments removed: {dedupeResults.budgetMerchantsRemoved}</div>
+						{#if dedupeResults.errors && dedupeResults.errors.length > 0}
+							<div class="mt-2 text-yellow-200">
+								Warnings: {dedupeResults.errors.length} issues encountered
 							</div>
 						{/if}
 					</div>


### PR DESCRIPTION
Add an admin tool to deduplicate merchants that only differ in case to ensure data consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e2e4cd3-ea27-4899-a550-4f0518af7d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e2e4cd3-ea27-4899-a550-4f0518af7d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

