### PR TITLE
Fix ccbilling auth redirect bug

### DIFF
--- a/webapp/src/routes/projects/ccbilling/admin/+page.server.js
+++ b/webapp/src/routes/projects/ccbilling/admin/+page.server.js
@@ -1,4 +1,7 @@
+import { redirect } from '@sveltejs/kit';
 import { requireUser } from '$lib/server/require-user.js';
+
+const HTML_TEMPORARY_REDIRECT = 307;
 
 /**
  * Admin page server-side logic
@@ -7,7 +10,9 @@ import { requireUser } from '$lib/server/require-user.js';
 export async function load(event) {
 	// Require authentication
 	const authResult = await requireUser(event);
-	if (authResult instanceof Response) return authResult;
+	if (authResult instanceof Response) {
+		throw redirect(HTML_TEMPORARY_REDIRECT, '/notauthorised');
+	}
 
 	// Return empty data - the page will fetch its own data from the API
 	return {};

--- a/webapp/tests/ccbilling-admin-page-server.test.js
+++ b/webapp/tests/ccbilling-admin-page-server.test.js
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { load } from '../src/routes/projects/ccbilling/admin/+page.server.js';
 
+// Mock SvelteKit redirect function
+vi.mock('@sveltejs/kit', () => ({
+	redirect: vi.fn()
+}));
+
 // Mock the requireUser function
 vi.mock('$lib/server/require-user.js', () => ({
 	requireUser: vi.fn()
@@ -10,6 +15,7 @@ describe('CCBilling Admin Page Server Route', () => {
 	let mockEvent;
 	let mockPlatform;
 	let mockRequireUser;
+	let mockRedirect;
 
 	beforeEach(async () => {
 		vi.clearAllMocks();
@@ -42,16 +48,16 @@ describe('CCBilling Admin Page Server Route', () => {
 
 		// Get mocked functions
 		mockRequireUser = (await import('$lib/server/require-user.js')).requireUser;
+		mockRedirect = (await import('@sveltejs/kit')).redirect;
 	});
 
 	describe('load function', () => {
-		it('should return authentication response when user is not authenticated', async () => {
+		it('should redirect to /notauthorised when user is not authenticated', async () => {
 			const authResponse = new Response('Not authenticated', { status: 401 });
 			mockRequireUser.mockResolvedValue(authResponse);
 
-			const result = await load(mockEvent);
-			expect(result).toBe(authResponse);
-			expect(result.status).toBe(401);
+			await expect(load(mockEvent)).rejects.toThrow();
+			expect(mockRedirect).toHaveBeenCalledWith(307, '/notauthorised');
 		});
 
 		it('should return empty data when user is authenticated', async () => {


### PR DESCRIPTION
Redirect users to the `/notauthorised` page on ccbilling admin authentication failure instead of showing an internal error.

Previously, the ccbilling admin page directly returned the authentication failure `Response` from `requireUser`, leading to an internal error page. This change updates the page to `throw redirect(307, '/notauthorised')`, aligning its behavior with other authenticated pages in the ccbilling project for a consistent user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-171f9eed-393c-4ce1-9a52-43819be6f001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-171f9eed-393c-4ce1-9a52-43819be6f001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

