### PR TITLE
fix: upgrade lodash-es dependency to resolve security vulnerabilities

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -62,6 +62,7 @@
 				"highlight.js": "^11.11.1",
 				"jsdom": "^29.0.2",
 				"kolorist": "^1.8.0",
+				"lodash-es": "^4.18.1",
 				"magic-string": "^0.30.21",
 				"mdsvex": "^0.12.7",
 				"mermaid": "11.14.0",
@@ -9077,9 +9078,9 @@
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,7 +5,8 @@
 	"overrides": {
 		"@sveltejs/kit": {
 			"cookie": "^0.7.2"
-		}
+		},
+		"lodash-es": "^4.18.1"
 	},
 	"scripts": {
 		"postinstall": "node scripts/copy-pdf-worker.js",
@@ -61,6 +62,7 @@
 		"highlight.js": "^11.11.1",
 		"jsdom": "^29.0.2",
 		"kolorist": "^1.8.0",
+		"lodash-es": "^4.18.1",
 		"magic-string": "^0.30.21",
 		"mdsvex": "^0.12.7",
 		"mermaid": "11.14.0",


### PR DESCRIPTION
Upgrades `lodash-es` dependency to `^4.18.1` to resolve multiple security vulnerabilities including code injection and prototype pollution. Updates package.json with overrides and regenerates the lockfile.

---
*PR created automatically by Jules for task [6316695494895129691](https://jules.google.com/task/6316695494895129691) started by @nickbrett1*