### PR TITLE
Fix Bilt Cardless Parser to exclude negative payments

### DIFF
--- a/webapp/src/lib/utils/ccbilling-parsers/bilt-cardless-parser.js
+++ b/webapp/src/lib/utils/ccbilling-parsers/bilt-cardless-parser.js
@@ -247,6 +247,9 @@ export class BiltCardlessParser extends BaseParser {
 						// Skip payments in the payments section, but keep refunds (negative amounts in credits)
 						if (inPayments && amount > 0) continue; // Positive in payments section is likely a payment
 
+						// Skip if this is a payment using shared base parser method
+						if (this.isPaymentToCard(description)) continue;
+
 						const charge = {
 							merchant: this.cleanMerchantName(description),
 							amount: amount, // Use raw amount (negative for credits)
@@ -274,5 +277,18 @@ export class BiltCardlessParser extends BaseParser {
 		}
 
 		return charges;
+	}
+
+	/**
+	 * Returns the keywords for identifying a payment to the card.
+	 * @returns {string[]}
+	 */
+	getPaymentKeywords() {
+		return [
+			'payment thank you',
+			'payment',
+			'online payment',
+			'payment received'
+		];
 	}
 }

--- a/webapp/tests/lib/utils/ccbilling-parsers/bilt-cardless-parser.test.js
+++ b/webapp/tests/lib/utils/ccbilling-parsers/bilt-cardless-parser.test.js
@@ -116,6 +116,22 @@ Total payments and credits in this period -$1,076.47
 			});
 		});
 
+		it('should exclude PAYMENT with negative amounts in payments section', () => {
+			const text = `
+Payments and credits
+Date Description Amount
+Mar 7, 2026 PAYMENT -$20,505.78
+Mar 7, 2026 MERCHANDISE RETURN -$79.34
+Total payments and credits in this period -$20,585.12
+			`;
+			const charges = parser.extractCharges(text);
+			expect(charges).toHaveLength(1);
+			expect(charges[0]).toMatchObject({
+				merchant: 'Merchandise Return',
+				amount: -79.34,
+			});
+		});
+
 		it('should extract from fees section', () => {
 			const text = `
 Fees


### PR DESCRIPTION
Fixes an issue in the Bilt Cardless parser where payment lines presented with negative amounts were mistakenly categorized as normal charges rather than being ignored. Includes updated unit tests.

---
*PR created automatically by Jules for task [8929415152228590153](https://jules.google.com/task/8929415152228590153) started by @nickbrett1*