### PR TITLE
fix: update particle colors for tsparticles v4 compatibility

### DIFF
--- a/webapp/src/lib/client/particleConfig.js
+++ b/webapp/src/lib/client/particleConfig.js
@@ -134,7 +134,7 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							value: generatePercentageValues(50, true), // Positive percentages
 							weight: '400',
 							particles: {
-								color: '#00FF9E', // Green for positive
+								color: { value: '#00FF9E' }, // Green for positive
 								size: { value: 8 }
 							}
 						},
@@ -144,7 +144,7 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							value: generatePercentageValues(50, false), // Negative percentages
 							weight: '400',
 							particles: {
-								color: '#FF0061', // Red for negative
+								color: { value: '#FF0061' }, // Red for negative
 								size: { value: 8 }
 							}
 						}
@@ -173,7 +173,7 @@ function createTextParticleConfig(textConfig, overrides = {}) {
 		particles: {
 			...baseConfig.particles,
 			links: {
-				color: '#22c55e',
+				color: { value: '#22c55e' },
 				distance: 150,
 				enable: true,
 				opacity: 0.3,
@@ -216,7 +216,7 @@ export const createErrorParticleConfig = (overrides = {}) => {
 			value: ['404', '404', '404'],
 			weight: '400',
 			particles: {
-				color: '#22c55e', // Green
+				color: { value: '#22c55e' }, // Green
 				size: { value: 12 }
 			}
 		},
@@ -226,7 +226,7 @@ export const createErrorParticleConfig = (overrides = {}) => {
 			value: ['ERROR', 'ERROR'],
 			weight: '400',
 			particles: {
-				color: '#FF0061', // Red
+				color: { value: '#FF0061' }, // Red
 				size: { value: 12 }
 			}
 		}
@@ -249,7 +249,7 @@ export const createAuthParticleConfig = (overrides = {}) => {
 			value: ['AUTH', 'AUTH', 'AUTH'],
 			weight: '400',
 			particles: {
-				color: '#22c55e', // Green
+				color: { value: '#22c55e' }, // Green
 				size: { value: 12 }
 			}
 		},
@@ -259,7 +259,7 @@ export const createAuthParticleConfig = (overrides = {}) => {
 			value: ['LOGIN', 'LOGIN'],
 			weight: '400',
 			particles: {
-				color: '#fbbf24', // Yellow/amber
+				color: { value: '#fbbf24' }, // Yellow/amber
 				size: { value: 12 }
 			}
 		}

--- a/webapp/tests/lib/client/particleConfig.test.js
+++ b/webapp/tests/lib/client/particleConfig.test.js
@@ -65,12 +65,12 @@ describe('ParticleConfig', () => {
 
 			// Check positive percentages (green)
 			const positiveText = config.particles.shape.options.text[0];
-			expect(positiveText.particles.color).toBe('#00FF9E');
+			expect(positiveText.particles.color).toEqual({ value: '#00FF9E' });
 			expect(positiveText.value).toHaveLength(50);
 
 			// Check negative percentages (red)
 			const negativeText = config.particles.shape.options.text[1];
-			expect(negativeText.particles.color).toBe('#FF0061');
+			expect(negativeText.particles.color).toEqual({ value: '#FF0061' });
 			expect(negativeText.value).toHaveLength(50);
 		});
 
@@ -105,12 +105,12 @@ describe('ParticleConfig', () => {
 
 			// Check 404 text (green)
 			const error404Text = config.particles.shape.options.text[0];
-			expect(error404Text.particles.color).toBe('#22c55e');
+			expect(error404Text.particles.color).toEqual({ value: '#22c55e' });
 			expect(error404Text.value).toEqual(['404', '404', '404']);
 
 			// Check ERROR text (red)
 			const errorText = config.particles.shape.options.text[1];
-			expect(errorText.particles.color).toBe('#FF0061');
+			expect(errorText.particles.color).toEqual({ value: '#FF0061' });
 			expect(errorText.value).toEqual(['ERROR', 'ERROR']);
 		});
 
@@ -121,7 +121,7 @@ describe('ParticleConfig', () => {
 
 		it('should have correct link properties', () => {
 			const config = createErrorParticleConfig();
-			expect(config.particles.links.color).toBe('#22c55e');
+			expect(config.particles.links.color).toEqual({ value: '#22c55e' });
 			expect(config.particles.links.distance).toBe(150);
 			expect(config.particles.links.opacity).toBe(0.3);
 		});
@@ -152,12 +152,12 @@ describe('ParticleConfig', () => {
 
 			// Check AUTH text (green)
 			const authText = config.particles.shape.options.text[0];
-			expect(authText.particles.color).toBe('#22c55e');
+			expect(authText.particles.color).toEqual({ value: '#22c55e' });
 			expect(authText.value).toEqual(['AUTH', 'AUTH', 'AUTH']);
 
 			// Check LOGIN text (yellow/amber)
 			const loginText = config.particles.shape.options.text[1];
-			expect(loginText.particles.color).toBe('#fbbf24');
+			expect(loginText.particles.color).toEqual({ value: '#fbbf24' });
 			expect(loginText.value).toEqual(['LOGIN', 'LOGIN']);
 		});
 
@@ -168,7 +168,7 @@ describe('ParticleConfig', () => {
 
 		it('should have correct link properties', () => {
 			const config = createAuthParticleConfig();
-			expect(config.particles.links.color).toBe('#22c55e');
+			expect(config.particles.links.color).toEqual({ value: '#22c55e' });
 			expect(config.particles.links.distance).toBe(150);
 			expect(config.particles.links.opacity).toBe(0.3);
 		});


### PR DESCRIPTION
- Updated the `color` property within `tsparticles` configuration to use the object format `{ value: '<color>' }` as required by version 4.
- This restores the green and red percentage colors on the background of the landing page, which were previously displaying as white due to the configuration format breaking change.
- Updated related unit tests to assert the correct expected structure.

---
*PR created automatically by Jules for task [11171306303549018511](https://jules.google.com/task/11171306303549018511) started by @nickbrett1*