### PR TITLE
fix: Downgrade tsParticles to v3 to restore text color options

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -12,10 +12,10 @@
 				"@stripe/stripe-js": "^9.5.0",
 				"@threlte/core": "^8.5.14",
 				"@threlte/extras": "^9.18.0",
-				"@tsparticles/engine": "^4.0.2",
-				"@tsparticles/interaction-external-trail": "^4.0.2",
-				"@tsparticles/shape-text": "^4.0.2",
-				"@tsparticles/slim": "^4.0.2",
+				"@tsparticles/engine": "^3.0.0",
+				"@tsparticles/interaction-external-trail": "^3.0.0",
+				"@tsparticles/shape-text": "^3.0.0",
+				"@tsparticles/slim": "^3.0.0",
 				"apexcharts": "^5.12.0",
 				"arctic": "^3.7.0",
 				"cookie": "^1.1.1",
@@ -30,7 +30,7 @@
 				"stripe": "^22.1.1",
 				"three": "^0.184.0",
 				"tippy.js": "^6.3.7",
-				"tsparticles": "^4.0.2"
+				"tsparticles": "^3.0.0"
 			},
 			"devDependencies": {
 				"@cloudflare/vite-plugin": "^1.37.1",
@@ -3485,9 +3485,9 @@
 			}
 		},
 		"node_modules/@tsparticles/basic": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-4.0.2.tgz",
-			"integrity": "sha512-SPUeC2NvRcFLiLbZK+XMh/hzAHeb5he0Eqi12RH5IOPVG0TQx8Hw8NiTcNFiY3dQMmTQfT9tvcVhw8KCi7aauw==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-3.9.1.tgz",
+			"integrity": "sha512-ijr2dHMx0IQHqhKW3qA8tfwrR2XYbbWYdaJMQuBo2CkwBVIhZ76U+H20Y492j/NXpd1FUnt2aC0l4CEVGVGdeQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -3504,45 +3504,22 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-hex-color": "4.0.2",
-				"@tsparticles/plugin-hsl-color": "4.0.2",
-				"@tsparticles/plugin-move": "4.0.2",
-				"@tsparticles/plugin-rgb-color": "4.0.2",
-				"@tsparticles/shape-circle": "4.0.2",
-				"@tsparticles/updater-opacity": "4.0.2",
-				"@tsparticles/updater-out-modes": "4.0.2",
-				"@tsparticles/updater-paint": "4.0.2",
-				"@tsparticles/updater-size": "4.0.2"
-			}
-		},
-		"node_modules/@tsparticles/canvas-utils": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/canvas-utils/-/canvas-utils-4.0.2.tgz",
-			"integrity": "sha512-tG8YyaBvU40uS67TdkZ9DpA9MmpT1vKfIK6iAkpR5dsNNY47It4xjeiCLgSGN/ugrjnYPiM5969+FPnEV8srcQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/matteobruni"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/tsparticles"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://www.buymeacoffee.com/matteobruni"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+				"@tsparticles/engine": "3.9.1",
+				"@tsparticles/move-base": "3.9.1",
+				"@tsparticles/plugin-hex-color": "3.9.1",
+				"@tsparticles/plugin-hsl-color": "3.9.1",
+				"@tsparticles/plugin-rgb-color": "3.9.1",
+				"@tsparticles/shape-circle": "3.9.1",
+				"@tsparticles/updater-color": "3.9.1",
+				"@tsparticles/updater-opacity": "3.9.1",
+				"@tsparticles/updater-out-modes": "3.9.1",
+				"@tsparticles/updater-size": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/engine": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-4.0.2.tgz",
-			"integrity": "sha512-B7xggalqpi2mu+rkPAV4abMrsqkdayYmeg78SHrOjJy6ApTMcWD0U2/zvxAFnc1U8EnsRBX8vIiTwBHdNZmp0A==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-3.9.1.tgz",
+			"integrity": "sha512-DpdgAhWMZ3Eh2gyxik8FXS6BKZ8vyea+Eu5BC4epsahqTGY9V3JGGJcXC6lRJx6cPMAx1A0FaQAojPF3v6rkmQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -3561,203 +3538,162 @@
 			"license": "MIT"
 		},
 		"node_modules/@tsparticles/interaction-external-attract": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-4.0.2.tgz",
-			"integrity": "sha512-yq7FvTupYFtKwy4cI0ymcqhEpkESeueoMiMyGZ9rFj7VIxDabe/qO723oiPQGBuB4o6gYg3uCw0CbgOwyzI3RA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-3.9.1.tgz",
+			"integrity": "sha512-5AJGmhzM9o4AVFV24WH5vSqMBzOXEOzIdGLIr+QJf4fRh9ZK62snsusv/ozKgs2KteRYQx+L7c5V3TqcDy2upg==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-bounce": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-4.0.2.tgz",
-			"integrity": "sha512-bDjfbC29bwtlxQDmD5SNL296VVX68byaPQ2v2TVhSF57joMWNHUi/vVN0q+P9FHfnvJpUT41zhhfOznUn097EA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-3.9.1.tgz",
+			"integrity": "sha512-bv05+h70UIHOTWeTsTI1AeAmX6R3s8nnY74Ea6p6AbQjERzPYIa0XY19nq/hA7+Nrg+EissP5zgoYYeSphr85A==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-bubble": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-4.0.2.tgz",
-			"integrity": "sha512-iTZmC+SafYM+8b4iXnyy7bACyWaU/UtF1QD1lvloN4pUFuLg71/RmudJFbvsM8s0H3nqYpRXxNDvtOOQxmqpGg==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-3.9.1.tgz",
+			"integrity": "sha512-tbd8ox/1GPl+zr+KyHQVV1bW88GE7OM6i4zql801YIlCDrl9wgTDdDFGIy9X7/cwTvTrCePhrfvdkUamXIribQ==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-connect": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-4.0.2.tgz",
-			"integrity": "sha512-Ov25f0w5821ov4HrWvDw+zQBwOD//8wsYO7TBa7M2N3kvZhIdiW5T/kVXa+AbqEIMCCbqvqXwhj6oxlRe764fQ==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-3.9.1.tgz",
+			"integrity": "sha512-sq8YfUNsIORjXHzzW7/AJQtfi/qDqLnYG2qOSE1WOsog39MD30RzmiOloejOkfNeUdcGUcfsDgpUuL3UhzFUOA==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.2"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
-			}
-		},
-		"node_modules/@tsparticles/interaction-external-destroy": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-destroy/-/interaction-external-destroy-4.0.2.tgz",
-			"integrity": "sha512-zmfg35KuAvUzFea8GO3cRax5NdwuGNPOXoIJoEkfeAQbtXthThJx0XVKyRWu8T3Mj5PDMY4wn2+SuT0YDkaOIw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
-			}
-		},
-		"node_modules/@tsparticles/interaction-external-drag": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-drag/-/interaction-external-drag-4.0.2.tgz",
-			"integrity": "sha512-LZTtzFB1Sv0nGUGyqeFuZAaZm8wAW0fxZIyGiCk05hJN5dw31rYhB9psMb1OVJFrqRqBFbLZ5oe59Q/aguSp3g==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-grab": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-4.0.2.tgz",
-			"integrity": "sha512-q+mjFoAlRHoj4WtARjy2BNGqZzRHzbU2ONO9zeTO48mLwSlSkOyJdGbLn/SnElKG6c4g5C+Gdwp2co/DjScqVQ==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-3.9.1.tgz",
+			"integrity": "sha512-QwXza+sMMWDaMiFxd8y2tJwUK6c+nNw554+/9+tEZeTTk2fCbB0IJ7p/TH6ZGWDL0vo2muK54Njv2fEey191ow==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.2"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
-			}
-		},
-		"node_modules/@tsparticles/interaction-external-parallax": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-parallax/-/interaction-external-parallax-4.0.2.tgz",
-			"integrity": "sha512-5lWgMNCQVvEnsESOto1MqfStI7716MYK/8ZTIKhx3VhdQTjtRzy683/KJLWZZTkLAsQx1s+JcFuSLJsa9fskUA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-pause": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-4.0.2.tgz",
-			"integrity": "sha512-eVZFoClNLJMlvLXKIInTU2nBtQUubCk3AxJTY6prsO7iDDCHREyt9YfT649SkhY/kMmrzuPwe7yNZ3ZDUR/VLw==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-3.9.1.tgz",
+			"integrity": "sha512-Gzv4/FeNir0U/tVM9zQCqV1k+IAgaFjDU3T30M1AeAsNGh/rCITV2wnT7TOGFkbcla27m4Yxa+Fuab8+8pzm+g==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-push": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-4.0.2.tgz",
-			"integrity": "sha512-9uTn8N/lRz0EQNBvKu4xoCYBySyQs2jGQnfC6ZERI1tK8QAXRKM+3Xp53eau6Ji0ZiOFoSGpT1ChsYG6GZKGog==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-3.9.1.tgz",
+			"integrity": "sha512-GvnWF9Qy4YkZdx+WJL2iy9IcgLvzOIu3K7aLYJFsQPaxT8d9TF8WlpoMlWKnJID6H5q4JqQuMRKRyWH8aAKyQw==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-remove": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-4.0.2.tgz",
-			"integrity": "sha512-eobnMHAiiZQZawRRK6bmsLEsiSrqyKr1RQXVEHHkr2Syiialw4+e1afLg/BwL9Rm7nDmYKwWXjlJ2ky36S//bA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-3.9.1.tgz",
+			"integrity": "sha512-yPThm4UDWejDOWW5Qc8KnnS2EfSo5VFcJUQDWc1+Wcj17xe7vdSoiwwOORM0PmNBzdDpSKQrte/gUnoqaUMwOA==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-repulse": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-4.0.2.tgz",
-			"integrity": "sha512-cPJDjj/qfQp8VyKEsgkniawlpfrv5hG69Mq9rWE7z5tQWbvi0NaPDriU1fFp4rc+DvAU1FwfFemqaFCw8yJUtQ==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-3.9.1.tgz",
+			"integrity": "sha512-/LBppXkrMdvLHlEKWC7IykFhzrz+9nebT2fwSSFXK4plEBxDlIwnkDxd3FbVOAbnBvx4+L8+fbrEx+RvC8diAw==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-slow": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-4.0.2.tgz",
-			"integrity": "sha512-jVd1uSu/jrJNj7LYq5+/SK5vMlR7Syp6vhr1pjXx9Ov+VFROcPnNT1hgMcmD2eu/sWww+rnJjn+05f0CEkgoAA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-3.9.1.tgz",
+			"integrity": "sha512-1ZYIR/udBwA9MdSCfgADsbDXKSFS0FMWuPWz7bm79g3sUxcYkihn+/hDhc6GXvNNR46V1ocJjrj0u6pAynS1KQ==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-trail": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-trail/-/interaction-external-trail-4.0.2.tgz",
-			"integrity": "sha512-zTtqb8pfYyXDyu0EOxyxQ+euuLZJZiztWnc4SRjj/Zavdv5Sr5dUo8mtieF+1w0Z2pjN6WkqoFmnY961WpVdSA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-trail/-/interaction-external-trail-3.9.1.tgz",
+			"integrity": "sha512-Au0v2oiqfKTemI/4bzjD4dUXzIngB5Q2T4nJcMCYpP24uZfwZh5xTjUMH7gyJyyaRTdMl9IJrp8ySjyYbLfeGg==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-particles-attract": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-4.0.2.tgz",
-			"integrity": "sha512-a+4xLjE3apwtWgzJEmH0ENILu5/V072OkYIQ+DBn7mYpd3loz+JvngDiQgL2y3KbRQw/3qnCMgnGqt0+LiLZ0Q==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-3.9.1.tgz",
+			"integrity": "sha512-CYYYowJuGwRLUixQcSU/48PTKM8fCUYThe0hXwQ+yRMLAn053VHzL7NNZzKqEIeEyt5oJoy9KcvubjKWbzMBLQ==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-particles-collisions": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-4.0.2.tgz",
-			"integrity": "sha512-Daw9x9ugAd5mTBtl56Tf2V63prNrn2jJLHgAt9E0vyeItQxIOlpgeEpT/oj8b4tnav1g0cx8ZP5RHRanjO8KNQ==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-3.9.1.tgz",
+			"integrity": "sha512-ggGyjW/3v1yxvYW1IF1EMT15M6w31y5zfNNUPkqd/IXRNPYvm0Z0ayhp+FKmz70M5p0UxxPIQHTvAv9Jqnuj8w==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/interaction-particles-links": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-4.0.2.tgz",
-			"integrity": "sha512-fGrcaDUXE7ScwXBYzS33h61HJ7BIQi7aHXE/SL2NzyC7DkVee50X9XuqKOw51pNA3mM/Fk0xBL8PvoRjqf9tDA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-3.9.1.tgz",
+			"integrity": "sha512-MsLbMjy1vY5M5/hu/oa5OSRZAUz49H3+9EBMTIOThiX+a+vpl3sxc9AqNd9gMsPbM4WJlub8T6VBZdyvzez1Vg==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.2"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
+				"@tsparticles/engine": "3.9.1"
+			}
+		},
+		"node_modules/@tsparticles/move-base": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/move-base/-/move-base-3.9.1.tgz",
+			"integrity": "sha512-X4huBS27d8srpxwOxliWPUt+NtCwY+8q/cx1DvQxyqmTA8VFCGpcHNwtqiN+9JicgzOvSuaORVqUgwlsc7h4pQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
+			}
+		},
+		"node_modules/@tsparticles/move-parallax": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/move-parallax/-/move-parallax-3.9.1.tgz",
+			"integrity": "sha512-whlOR0bVeyh6J/hvxf/QM3DqvNnITMiAQ0kro6saqSDItAVqg4pYxBfEsSOKq7EhjxNvfhhqR+pFMhp06zoCVA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/plugin-absorbers": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-4.0.2.tgz",
-			"integrity": "sha512-3ox6FMzsvdkop2TsbzzGbAsyIfHl2f/KjXdPKrkSC+EHAwlKufqDB1xhVscdMH5SuhDCuDwlqsD1sxxrDv5lCQ==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-3.9.1.tgz",
+			"integrity": "sha512-q9SQllpbPPgw1+euxHPYCFawOVUazQkkwnleiIgpYSiimlCyjIdwGnFPSNe1Sypzqmr2h6oOyX2vkK5ZVNEu8A==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
-			},
-			"peerDependenciesMeta": {
-				"@tsparticles/plugin-interactivity": {
-					"optional": true
-				}
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/plugin-easing-quad": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-4.0.2.tgz",
-			"integrity": "sha512-Zdntgznxe0SrtFfMSuwIDRLSi4iowiv3eiwcZJXsP2jPrxG7gR9PMG6DkbhmgU3P2BafRHh0mUzLY3NWOH9chQ==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-3.9.1.tgz",
+			"integrity": "sha512-C2UJOca5MTDXKUTBXj30Kiqr5UyID+xrY/LxicVWWZPczQW2bBxbIbfq9ULvzGDwBTxE2rdvIB8YFKmDYO45qw==",
 			"funding": [
 				{
 					"type": "github",
@@ -3773,29 +3709,23 @@
 				}
 			],
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/plugin-emitters": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-4.0.2.tgz",
-			"integrity": "sha512-j17LTe0n/UkW40GALIV9IvmGnDyQkxeUXFi1kUTCv0h9KMoHWjFO3nvcOEmWHqQuVfxT5+4F3WrR44gMwvsrNw==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-3.9.1.tgz",
+			"integrity": "sha512-h7opR8SoFWBmVHceDLJUerLENaPfkJSh2zQYvzmLj2L+V3VLS1QDgty+4QZVeZfqNROmgQw2eLFA5El1E0sqqw==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2"
-			},
-			"peerDependenciesMeta": {
-				"@tsparticles/plugin-interactivity": {
-					"optional": true
-				}
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/plugin-emitters-shape-circle": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-4.0.2.tgz",
-			"integrity": "sha512-6ZUq/lXW397f96+TVV+7GA6oaRomuh3hAaHSu4KwVgj7JkcVF5rNuIHL5eOaFIqIxlR/QaL3/mcR7MMM7W0CeA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-3.9.1.tgz",
+			"integrity": "sha512-z+9MsAPWr++sNz6N6303rRDjusW0BIPhHY51E5eXGDcRdOqrESDs6y99AJ/6Kdb/PpibCIYjFY9jVi2JJADPRA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3811,15 +3741,15 @@
 				}
 			],
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-emitters": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1",
+				"@tsparticles/plugin-emitters": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/plugin-emitters-shape-square": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-4.0.2.tgz",
-			"integrity": "sha512-4zFRWAV9Jt4VkwPaoopJNuLHf8UWIiQ0stdiwMw5agGOFfeBjSVfWqUEAxKhuOdNst3k50X44tmhDpESLmio4A==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-3.9.1.tgz",
+			"integrity": "sha512-dhA1c7FKs19B8lgTf25OTA3JoptNA+rjorsqCFuY1BZDI8g9E8DNqikUge14/W7nZN96+98hY+ghxSl4K2YsgA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3835,15 +3765,15 @@
 				}
 			],
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/plugin-emitters": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1",
+				"@tsparticles/plugin-emitters": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/plugin-hex-color": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-4.0.2.tgz",
-			"integrity": "sha512-wobR2XD42kLHt2wgj2Hd5c8/urcBgIg2Cs+2zo5j8GQkpY3Na0ofPrpojQXrC663Q8lhaC1EJ5spEM8wT3EzEA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-3.9.1.tgz",
+			"integrity": "sha512-vZgZ12AjUicJvk7AX4K2eAmKEQX/D1VEjEPFhyjbgI7A65eX72M465vVKIgNA6QArLZ1DLs7Z787LOE6GOBWsg==",
 			"funding": [
 				{
 					"type": "github",
@@ -3859,14 +3789,14 @@
 				}
 			],
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/plugin-hsl-color": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-4.0.2.tgz",
-			"integrity": "sha512-hCG+pGkqS+ucibQ2RGY3t/Uwh+llbSfRwf9qidDI9emlb3Mx2GoqGR15h2wMhEvNxf96I8G12hN1QFA3V9n1EA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-3.9.1.tgz",
+			"integrity": "sha512-jJd1iGgRwX6eeNjc1zUXiJivaqC5UE+SC2A3/NtHwwoQrkfxGWmRHOsVyLnOBRcCPgBp/FpdDe6DIDjCMO715w==",
 			"funding": [
 				{
 					"type": "github",
@@ -3882,32 +3812,14 @@
 				}
 			],
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
-			}
-		},
-		"node_modules/@tsparticles/plugin-interactivity": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-interactivity/-/plugin-interactivity-4.0.2.tgz",
-			"integrity": "sha512-e3RczVWDh0fZRSu8s1YA2QIpGIPdbQgUwbgrUiyNdKHgUTyOHmWTOKcnKMrRpwtt6PD1n3cR5ed8n6NUomLaGg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
-			}
-		},
-		"node_modules/@tsparticles/plugin-move": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-move/-/plugin-move-4.0.2.tgz",
-			"integrity": "sha512-rO7ITxNNGd+lZ6TiScXz5vhkpkfQL7hoXEdQZ8kKCgPEXpJX23GVLtAP9jNHSmzYQgFOmxoktuggWpqzdqoFhA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/plugin-rgb-color": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-4.0.2.tgz",
-			"integrity": "sha512-/6VaPUTdhbV+1TMYBJ+1NhAsKaIasH0rSKVTUUWzwFDdFIl93NblGsjwZgk/7WcMEbxJ4j64nR/r8YjgUAIGSA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-3.9.1.tgz",
+			"integrity": "sha512-SBxk7f1KBfXeTnnklbE2Hx4jBgh6I6HOtxb+Os1gTp0oaghZOkWcCD2dP4QbUu7fVNCMOcApPoMNC8RTFcy9wQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -3923,92 +3835,86 @@
 				}
 			],
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/shape-circle": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-4.0.2.tgz",
-			"integrity": "sha512-b64si1QRfj1wL27GIgdiKJzJb/iDuMnGRiEnuvnwxI7gL67qTjaDRmCS5+16QBqfrttcm0mXp+JMqFsCmcMD+Q==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-3.9.1.tgz",
+			"integrity": "sha512-DqZFLjbuhVn99WJ+A9ajz9YON72RtCcvubzq6qfjFmtwAK7frvQeb6iDTp6Ze9FUipluxVZWVRG4vWTxi2B+/g==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/shape-emoji": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-4.0.2.tgz",
-			"integrity": "sha512-UkkfkcvCayzBZO5wemOZ+n1A/StZ1xQi+TRvoNm4CbFU3Qan3VsrXQl6rQyrM84rDUCJ9Qw+/d7ZoZoQ3Kujuw==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-3.9.1.tgz",
+			"integrity": "sha512-ifvY63usuT+hipgVHb8gelBHSeF6ryPnMxAAEC1RGHhhXfpSRWMtE6ybr+pSsYU52M3G9+TF84v91pSwNrb9ZQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.2"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/shape-image": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-4.0.2.tgz",
-			"integrity": "sha512-rqsxPRGlwFu+AH/xdok+tBpi6rgKBUSiMHjlU4U86JZ7tkW+aLjtayovpd6zPep9N9SB3xrAz2rYWzbQOiUzMg==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-3.9.1.tgz",
+			"integrity": "sha512-fCA5eme8VF3oX8yNVUA0l2SLDKuiZObkijb0z3Ky0qj1HUEVlAuEMhhNDNB9E2iELTrWEix9z7BFMePp2CC7AA==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/shape-line": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-4.0.2.tgz",
-			"integrity": "sha512-jpKPn8r3DrVyiXOjdcEU7Qd0ZN1fthJ6Pd77pEeXqTt7uyFyhc9k6ZufriJdpv4pwlB6825HeFQzQ3ksWChn3w==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-3.9.1.tgz",
+			"integrity": "sha512-wT8NSp0N9HURyV05f371cHKcNTNqr0/cwUu6WhBzbshkYGy1KZUP9CpRIh5FCrBpTev34mEQfOXDycgfG0KiLQ==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/shape-polygon": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-4.0.2.tgz",
-			"integrity": "sha512-uEp05LzzIiST510v+coLWVGbiukR+AHx77qL/kuCk2Bhv/VSneob2qV2xi6tlAaOy5pqLWYlbL5od6XoGayRzg==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-3.9.1.tgz",
+			"integrity": "sha512-dA77PgZdoLwxnliH6XQM/zF0r4jhT01pw5y7XTeTqws++hg4rTLV9255k6R6eUqKq0FPSW1/WBsBIl7q/MmrqQ==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/shape-square": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-4.0.2.tgz",
-			"integrity": "sha512-aqbzmf0GWTOpZQJ4w266OhNuCyK1NMUpPEh0gSB5zdXUmPozEDGtsMr5xTdvoCdd9iIfsconIAmG0Cf3tSr3Ng==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-3.9.1.tgz",
+			"integrity": "sha512-DKGkDnRyZrAm7T2ipqNezJahSWs6xd9O5LQLe5vjrYm1qGwrFxJiQaAdlb00UNrexz1/SA7bEoIg4XKaFa7qhQ==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/shape-star": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-4.0.2.tgz",
-			"integrity": "sha512-sRSANDemSoZFyq9ORkgBw+2Frq3zszN8jgtz17nNFmf0Ad2yUvThtgefa/vU1NTV+f4TgV0g448CFw6k/xB4iA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-3.9.1.tgz",
+			"integrity": "sha512-kdMJpi8cdeb6vGrZVSxTG0JIjCwIenggqk0EYeKAwtOGZFBgL7eHhF2F6uu1oq8cJAbXPujEoabnLsz6mW8XaA==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/shape-text": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-4.0.2.tgz",
-			"integrity": "sha512-YtzMcVWcdRPpu/xZ6kJAQug1AAdkUhV21mmOuAiXAesVrDIFWgNt9xlkpiH8VD61bQXRe87vIKcOXlD5WLxDaA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-3.9.1.tgz",
+			"integrity": "sha512-oNsLHI0lGkIXoUw3W598iwd7dtoHCDrwpwJRGnQzgfk6T5a9dCpSD5vDeQN89lr3BUbVui4lhxq+/TyC64oAqA==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.2"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/slim": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-4.0.2.tgz",
-			"integrity": "sha512-lxyijpUAAY+6TETDKstlaQuZOwZNJbBTDV6PyjFOsFs5bvrajPhs3TF5tj0PRUW8YGltc0nfZwDS5q8NwtUfVA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-3.9.1.tgz",
+			"integrity": "sha512-CL5cDmADU7sDjRli0So+hY61VMbdroqbArmR9Av+c1Fisa5ytr6QD7Jv62iwU2S6rvgicEe9OyRmSy5GIefwZw==",
 			"funding": [
 				{
 					"type": "github",
@@ -4025,133 +3931,140 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/basic": "4.0.2",
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/interaction-external-attract": "4.0.2",
-				"@tsparticles/interaction-external-bounce": "4.0.2",
-				"@tsparticles/interaction-external-bubble": "4.0.2",
-				"@tsparticles/interaction-external-connect": "4.0.2",
-				"@tsparticles/interaction-external-destroy": "4.0.2",
-				"@tsparticles/interaction-external-grab": "4.0.2",
-				"@tsparticles/interaction-external-parallax": "4.0.2",
-				"@tsparticles/interaction-external-pause": "4.0.2",
-				"@tsparticles/interaction-external-push": "4.0.2",
-				"@tsparticles/interaction-external-remove": "4.0.2",
-				"@tsparticles/interaction-external-repulse": "4.0.2",
-				"@tsparticles/interaction-external-slow": "4.0.2",
-				"@tsparticles/interaction-particles-attract": "4.0.2",
-				"@tsparticles/interaction-particles-collisions": "4.0.2",
-				"@tsparticles/interaction-particles-links": "4.0.2",
-				"@tsparticles/plugin-easing-quad": "4.0.2",
-				"@tsparticles/plugin-interactivity": "4.0.2",
-				"@tsparticles/shape-emoji": "4.0.2",
-				"@tsparticles/shape-image": "4.0.2",
-				"@tsparticles/shape-line": "4.0.2",
-				"@tsparticles/shape-polygon": "4.0.2",
-				"@tsparticles/shape-square": "4.0.2",
-				"@tsparticles/shape-star": "4.0.2",
-				"@tsparticles/updater-life": "4.0.2",
-				"@tsparticles/updater-paint": "4.0.2",
-				"@tsparticles/updater-rotate": "4.0.2"
+				"@tsparticles/basic": "3.9.1",
+				"@tsparticles/engine": "3.9.1",
+				"@tsparticles/interaction-external-attract": "3.9.1",
+				"@tsparticles/interaction-external-bounce": "3.9.1",
+				"@tsparticles/interaction-external-bubble": "3.9.1",
+				"@tsparticles/interaction-external-connect": "3.9.1",
+				"@tsparticles/interaction-external-grab": "3.9.1",
+				"@tsparticles/interaction-external-pause": "3.9.1",
+				"@tsparticles/interaction-external-push": "3.9.1",
+				"@tsparticles/interaction-external-remove": "3.9.1",
+				"@tsparticles/interaction-external-repulse": "3.9.1",
+				"@tsparticles/interaction-external-slow": "3.9.1",
+				"@tsparticles/interaction-particles-attract": "3.9.1",
+				"@tsparticles/interaction-particles-collisions": "3.9.1",
+				"@tsparticles/interaction-particles-links": "3.9.1",
+				"@tsparticles/move-parallax": "3.9.1",
+				"@tsparticles/plugin-easing-quad": "3.9.1",
+				"@tsparticles/shape-emoji": "3.9.1",
+				"@tsparticles/shape-image": "3.9.1",
+				"@tsparticles/shape-line": "3.9.1",
+				"@tsparticles/shape-polygon": "3.9.1",
+				"@tsparticles/shape-square": "3.9.1",
+				"@tsparticles/shape-star": "3.9.1",
+				"@tsparticles/updater-life": "3.9.1",
+				"@tsparticles/updater-rotate": "3.9.1",
+				"@tsparticles/updater-stroke-color": "3.9.1"
+			}
+		},
+		"node_modules/@tsparticles/updater-color": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-color/-/updater-color-3.9.1.tgz",
+			"integrity": "sha512-XGWdscrgEMA8L5E7exsE0f8/2zHKIqnTrZymcyuFBw2DCB6BIV+5z6qaNStpxrhq3DbIxxhqqcybqeOo7+Alpg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-destroy": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-4.0.2.tgz",
-			"integrity": "sha512-WLE+UtHU1PAr4dp0h9aNSmrr/+bEQbvUkIBXh1Zv1LoE3FYhBLyfoz+0BcIOr8atD8u2hOUvtyLBewl4L1hkFA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-3.9.1.tgz",
+			"integrity": "sha512-MjMzEhZwCQIbxO6ZRM0eXsHVwmlXuUqwC43WCPZCpjhK3AJrMu3KR4xsJieFTWIbVNguAvbgoTB10FfJOUU5VA==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-life": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-4.0.2.tgz",
-			"integrity": "sha512-ezqVL8aGjY1vsYtmVujxQL2FBCfIXFADwoCpyAnHaZ6Wb1YZTyYx+cCbitcHy53L99L9RSaJELe8WuH8K2P/tQ==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-3.9.1.tgz",
+			"integrity": "sha512-Oi8aF2RIwMMsjssUkCB6t3PRpENHjdZf6cX92WNfAuqXtQphr3OMAkYFJFWkvyPFK22AVy3p/cFt6KE5zXxwAA==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-opacity": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-4.0.2.tgz",
-			"integrity": "sha512-TLvjO2aoGGri4qToNwcbhEnklXow8ePE7r6wrhsr6UQUisuV2WOgVfY8qazy/wQ/VITf/UhFpeAVUUxxB7LvUw==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-3.9.1.tgz",
+			"integrity": "sha512-w778LQuRZJ+IoWzeRdrGykPYSSaTeWfBvLZ2XwYEkh/Ss961InOxZKIpcS6i5Kp/Zfw0fS1ZAuqeHwuj///Osw==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-out-modes": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-4.0.2.tgz",
-			"integrity": "sha512-9Sdg1J/1IudnbpxzKsyhfnNzApBer/T9wFxf4q9QAMNsYMmHacBMMH5Dh0On4o1SWY5v2m2cnmivyouAOf8y0Q==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-3.9.1.tgz",
+			"integrity": "sha512-cKQEkAwbru+hhKF+GTsfbOvuBbx2DSB25CxOdhtW2wRvDBoCnngNdLw91rs+0Cex4tgEeibkebrIKFDDE6kELg==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
-			}
-		},
-		"node_modules/@tsparticles/updater-paint": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-paint/-/updater-paint-4.0.2.tgz",
-			"integrity": "sha512-McH84yJvnlldpf8AwIjAe/oiNYyrNQrWGM8657Q7JptWSFkElPYM4Ph7MtNXlvAlvmZ3OIJld+JK+eHXWa4Crg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-roll": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-4.0.2.tgz",
-			"integrity": "sha512-UuxKlEmrC9x/ID+KP0j1k/DsCzmZHUFgZ6C0cSbiIEf3roUXbFo6/u37XzpFE5pq6qlTqCRiI4+EJKoT6UaFtQ==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-3.9.1.tgz",
+			"integrity": "sha512-zl4JeM3gUBJ0uttmIsond3lrZ3f3AkItFeS0Lhj/7jiCKfUoRyyOMrcBk8R1AhW7lI+7ko1iBs3jhO0jnxz9vg==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-rotate": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-4.0.2.tgz",
-			"integrity": "sha512-SeCtW4MSqeQFVULOolevVahGwvugp5o/vcXBcCunULSNrivEluZ22GlLfvMMvajItb2UmK16NjHPZy4qP7ALyw==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-3.9.1.tgz",
+			"integrity": "sha512-9BfKaGfp28JN82MF2qs6Ae/lJr9EColMfMTHqSKljblwbpVDHte4umuwKl3VjbRt87WD9MGtla66NTUYl+WxuQ==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-size": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-4.0.2.tgz",
-			"integrity": "sha512-CIfmy8jimvo8C6HWJgLxy70v/L1vVvZ9zk4eFcf8AcLEykqEH6vXTO1xwm/XlZ5L5RhSlFrmM14pqYA2rWQVqw==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-3.9.1.tgz",
+			"integrity": "sha512-3NSVs0O2ApNKZXfd+y/zNhTXSFeG1Pw4peI8e6z/q5+XLbmue9oiEwoPy/tQLaark3oNj3JU7Q903ZijPyXSzw==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
+			}
+		},
+		"node_modules/@tsparticles/updater-stroke-color": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-stroke-color/-/updater-stroke-color-3.9.1.tgz",
+			"integrity": "sha512-3x14+C2is9pZYTg9T2TiA/aM1YMq4wLdYaZDcHm3qO30DZu5oeQq0rm/6w+QOGKYY1Z3Htg9rlSUZkhTHn7eDA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-tilt": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-4.0.2.tgz",
-			"integrity": "sha512-EvUE9IvBLq1OqSfNlxJl87Q7YCSnHy3Tz1bOpy1MjPr7K0a/j9n6RqowNjEqqOBXsXtThUmDmtyI9Bmnbq//SA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-3.9.1.tgz",
+			"integrity": "sha512-PB2yaoyXRmSk4iIVgjtRrzOxXMK9mjeAQHIJGtT4faq46Z8cbIIEFgjTwqrUV8qOrNg/h4sm5NE/s0qsTYjp1Q==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-twinkle": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-4.0.2.tgz",
-			"integrity": "sha512-ll8RUyEBRiA9eGiY2hyQ6duIG4Ao5uUSZN50oKoEnDLHic1jov6HrOikqvEBCgaSo949uZZUGGo6xg+nhOYlOA==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-3.9.1.tgz",
+			"integrity": "sha512-xgTcYr6LmP44IPIBeQmEExN2Y5Nfl3ikmC08eOh5nZy/ta6ORP+JTsprrnfuv/O2DwTyoqFLkZ16hZfkdc1yOQ==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tsparticles/updater-wobble": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-4.0.2.tgz",
-			"integrity": "sha512-1BaprT1jkCsSNRHby8DOSdi5cK7lsP50DkJjqG+SwjOQemj7JeGsPcedtrVxoFSLb8CtD7Coa86qua9mc0WrNw==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-3.9.1.tgz",
+			"integrity": "sha512-c99Ogy9q4QWO+zsDXol0UnpUwZiY2UucFb8ltuDv9AlbGUeprygoub8jhgT5pEDv+GdzWOJGSgq7rfgv9cHBrg==",
 			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.2"
+			"dependencies": {
+				"@tsparticles/engine": "3.9.1"
 			}
 		},
 		"node_modules/@tweenjs/tween.js": {
@@ -11645,9 +11558,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsparticles": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-4.0.2.tgz",
-			"integrity": "sha512-L5EU2tKqFOqrefL9njwVys1busOPMy8kdmnZeIz6G3l5s/3pL74+OOvgqyAgxIy2LTEeGgX3ZRTTx2shquKsag==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-3.9.1.tgz",
+			"integrity": "sha512-Y780IGSL4qjkZj7+fI92PV/cziHqLR/s6nnYri4K6vH3NQRmDK5D6pfskDO8T4Y96ChCWHY3uxPtOb/hKQ83Qg==",
 			"funding": [
 				{
 					"type": "github",
@@ -11664,20 +11577,19 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "4.0.2",
-				"@tsparticles/interaction-external-drag": "4.0.2",
-				"@tsparticles/interaction-external-trail": "4.0.2",
-				"@tsparticles/plugin-absorbers": "4.0.2",
-				"@tsparticles/plugin-emitters": "4.0.2",
-				"@tsparticles/plugin-emitters-shape-circle": "4.0.2",
-				"@tsparticles/plugin-emitters-shape-square": "4.0.2",
-				"@tsparticles/shape-text": "4.0.2",
-				"@tsparticles/slim": "4.0.2",
-				"@tsparticles/updater-destroy": "4.0.2",
-				"@tsparticles/updater-roll": "4.0.2",
-				"@tsparticles/updater-tilt": "4.0.2",
-				"@tsparticles/updater-twinkle": "4.0.2",
-				"@tsparticles/updater-wobble": "4.0.2"
+				"@tsparticles/engine": "3.9.1",
+				"@tsparticles/interaction-external-trail": "3.9.1",
+				"@tsparticles/plugin-absorbers": "3.9.1",
+				"@tsparticles/plugin-emitters": "3.9.1",
+				"@tsparticles/plugin-emitters-shape-circle": "3.9.1",
+				"@tsparticles/plugin-emitters-shape-square": "3.9.1",
+				"@tsparticles/shape-text": "3.9.1",
+				"@tsparticles/slim": "3.9.1",
+				"@tsparticles/updater-destroy": "3.9.1",
+				"@tsparticles/updater-roll": "3.9.1",
+				"@tsparticles/updater-tilt": "3.9.1",
+				"@tsparticles/updater-twinkle": "3.9.1",
+				"@tsparticles/updater-wobble": "3.9.1"
 			}
 		},
 		"node_modules/tweakpane": {
@@ -13145,22 +13057,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"extraneous": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yargs": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -96,10 +96,10 @@
 		"@stripe/stripe-js": "^9.5.0",
 		"@threlte/core": "^8.5.14",
 		"@threlte/extras": "^9.18.0",
-		"@tsparticles/engine": "^4.0.2",
-		"@tsparticles/interaction-external-trail": "^4.0.2",
-		"@tsparticles/shape-text": "^4.0.2",
-		"@tsparticles/slim": "^4.0.2",
+		"@tsparticles/engine": "^3.0.0",
+		"@tsparticles/interaction-external-trail": "^3.0.0",
+		"@tsparticles/shape-text": "^3.0.0",
+		"@tsparticles/slim": "^3.0.0",
 		"apexcharts": "^5.12.0",
 		"arctic": "^3.7.0",
 		"cookie": "^1.1.1",
@@ -114,6 +114,6 @@
 		"stripe": "^22.1.1",
 		"three": "^0.184.0",
 		"tippy.js": "^6.3.7",
-		"tsparticles": "^4.0.2"
+		"tsparticles": "^3.0.0"
 	}
 }


### PR DESCRIPTION
Downgrade `tsparticles` packages back to v3 to fix a regression where `text` shapes could no longer be individually colored based on text items (e.g., green for positive, red for negative).

In v4, individual overrides like `particles.color` nested inside the text options arrays fail to override the base configurations, and trying to assign an array of colors randomly applies them across particles instead of using specific color mapping. Reverting to v3 restores the expected functionality where specific item properties can be distinctly colored via options.

---
*PR created automatically by Jules for task [4776901013730971772](https://jules.google.com/task/4776901013730971772) started by @nickbrett1*