### PR TITLE
Upgrade tsparticles to v4

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -10167,6 +10167,16 @@
 				}
 			}
 		},
+		"node_modules/postcss-load-config/node_modules/yaml": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/postcss-safe-parser": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
@@ -12584,16 +12594,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/yaml": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/yargs": {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -12,10 +12,10 @@
 				"@stripe/stripe-js": "^9.5.0",
 				"@threlte/core": "^8.5.14",
 				"@threlte/extras": "^9.18.0",
-				"@tsparticles/engine": "^3.0.0",
-				"@tsparticles/interaction-external-trail": "^3.0.0",
-				"@tsparticles/shape-text": "^3.0.0",
-				"@tsparticles/slim": "^3.0.0",
+				"@tsparticles/engine": "^4.0.2",
+				"@tsparticles/interaction-external-trail": "^4.0.2",
+				"@tsparticles/shape-text": "^4.0.2",
+				"@tsparticles/slim": "^4.0.2",
 				"apexcharts": "^5.12.0",
 				"arctic": "^3.7.0",
 				"cookie": "^1.1.1",
@@ -30,7 +30,7 @@
 				"stripe": "^22.1.1",
 				"three": "^0.184.0",
 				"tippy.js": "^6.3.7",
-				"tsparticles": "^3.0.0"
+				"tsparticles": "^4.0.2"
 			},
 			"devDependencies": {
 				"@cloudflare/vite-plugin": "^1.37.1",
@@ -419,9 +419,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260517.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260517.1.tgz",
-			"integrity": "sha512-OjavgX6VpYoWlKg2xPgLKIhBeiJvNdwFVK8E1P6hF02wh1oEt1sZpTzbp9kdohprqjXo6UVqs7/AuIH0wxIcbw==",
+			"version": "4.20260518.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260518.1.tgz",
+			"integrity": "sha512-xXzGrbRi8RHRBNQFgXYkzrB4DgF0RXvmp8E1vCxoBmINpeitM/ZjVDd1CNC+N3uXjgcNjacoz4OgTa0rxgig1A==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0"
 		},
@@ -628,6 +628,448 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -986,6 +1428,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1003,6 +1448,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1020,6 +1468,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1037,6 +1488,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1054,6 +1508,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1071,6 +1528,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1088,6 +1548,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1105,6 +1568,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1122,6 +1588,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1145,6 +1614,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1168,6 +1640,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1191,6 +1666,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1214,6 +1692,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1237,6 +1718,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1260,6 +1744,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1283,6 +1770,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1610,6 +2100,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1629,6 +2122,9 @@
 			"integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1650,6 +2146,9 @@
 			"cpu": [
 				"riscv64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1670,6 +2169,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1689,6 +2191,9 @@
 			"integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1986,6 +2491,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2003,6 +2511,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2020,6 +2531,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2037,6 +2551,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2054,6 +2571,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2071,6 +2591,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2590,6 +3113,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2607,6 +3133,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2624,6 +3153,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2641,6 +3173,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2679,72 +3214,6 @@
 			"engines": {
 				"node": ">=14.0.0"
 			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/Brooooooklyn"
-			},
-			"peerDependencies": {
-				"@emnapi/core": "^1.7.1",
-				"@emnapi/runtime": "^1.7.1"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-			"version": "2.8.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "0BSD",
-			"optional": true
 		},
 		"node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
 			"version": "4.3.0",
@@ -2935,9 +3404,9 @@
 			}
 		},
 		"node_modules/@threlte/extras": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/@threlte/extras/-/extras-9.18.0.tgz",
-			"integrity": "sha512-dy3po3S+aA1HFdJ+n3iY//efe12Z0F1ffIBliZf8tR1rqUAerFWIwbNK4+/+JujFHXKVwh5DwSAib+dq7V0BSQ==",
+			"version": "9.19.0",
+			"resolved": "https://registry.npmjs.org/@threlte/extras/-/extras-9.19.0.tgz",
+			"integrity": "sha512-vj5A2Gh0hIDId86TK26tRhQPEuxQ1oVFGsnyrjWP3pTPSxHCcyqpi7mStlcc+QdUxkuUYyCKG64aD2TZdsmGdA==",
 			"license": "MIT",
 			"dependencies": {
 				"@threejs-kit/instanced-sprite-mesh": "^2.5.1",
@@ -2953,9 +3422,9 @@
 			}
 		},
 		"node_modules/@tsparticles/basic": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-3.9.1.tgz",
-			"integrity": "sha512-ijr2dHMx0IQHqhKW3qA8tfwrR2XYbbWYdaJMQuBo2CkwBVIhZ76U+H20Y492j/NXpd1FUnt2aC0l4CEVGVGdeQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-4.0.2.tgz",
+			"integrity": "sha512-SPUeC2NvRcFLiLbZK+XMh/hzAHeb5he0Eqi12RH5IOPVG0TQx8Hw8NiTcNFiY3dQMmTQfT9tvcVhw8KCi7aauw==",
 			"funding": [
 				{
 					"type": "github",
@@ -2972,22 +3441,45 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "3.9.1",
-				"@tsparticles/move-base": "3.9.1",
-				"@tsparticles/plugin-hex-color": "3.9.1",
-				"@tsparticles/plugin-hsl-color": "3.9.1",
-				"@tsparticles/plugin-rgb-color": "3.9.1",
-				"@tsparticles/shape-circle": "3.9.1",
-				"@tsparticles/updater-color": "3.9.1",
-				"@tsparticles/updater-opacity": "3.9.1",
-				"@tsparticles/updater-out-modes": "3.9.1",
-				"@tsparticles/updater-size": "3.9.1"
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-hex-color": "4.0.2",
+				"@tsparticles/plugin-hsl-color": "4.0.2",
+				"@tsparticles/plugin-move": "4.0.2",
+				"@tsparticles/plugin-rgb-color": "4.0.2",
+				"@tsparticles/shape-circle": "4.0.2",
+				"@tsparticles/updater-opacity": "4.0.2",
+				"@tsparticles/updater-out-modes": "4.0.2",
+				"@tsparticles/updater-paint": "4.0.2",
+				"@tsparticles/updater-size": "4.0.2"
+			}
+		},
+		"node_modules/@tsparticles/canvas-utils": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/canvas-utils/-/canvas-utils-4.0.2.tgz",
+			"integrity": "sha512-tG8YyaBvU40uS67TdkZ9DpA9MmpT1vKfIK6iAkpR5dsNNY47It4xjeiCLgSGN/ugrjnYPiM5969+FPnEV8srcQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/matteobruni"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/tsparticles"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://www.buymeacoffee.com/matteobruni"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/engine": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-3.9.1.tgz",
-			"integrity": "sha512-DpdgAhWMZ3Eh2gyxik8FXS6BKZ8vyea+Eu5BC4epsahqTGY9V3JGGJcXC6lRJx6cPMAx1A0FaQAojPF3v6rkmQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-4.0.2.tgz",
+			"integrity": "sha512-B7xggalqpi2mu+rkPAV4abMrsqkdayYmeg78SHrOjJy6ApTMcWD0U2/zvxAFnc1U8EnsRBX8vIiTwBHdNZmp0A==",
 			"funding": [
 				{
 					"type": "github",
@@ -3006,162 +3498,203 @@
 			"license": "MIT"
 		},
 		"node_modules/@tsparticles/interaction-external-attract": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-3.9.1.tgz",
-			"integrity": "sha512-5AJGmhzM9o4AVFV24WH5vSqMBzOXEOzIdGLIr+QJf4fRh9ZK62snsusv/ozKgs2KteRYQx+L7c5V3TqcDy2upg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-4.0.2.tgz",
+			"integrity": "sha512-yq7FvTupYFtKwy4cI0ymcqhEpkESeueoMiMyGZ9rFj7VIxDabe/qO723oiPQGBuB4o6gYg3uCw0CbgOwyzI3RA==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-bounce": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-3.9.1.tgz",
-			"integrity": "sha512-bv05+h70UIHOTWeTsTI1AeAmX6R3s8nnY74Ea6p6AbQjERzPYIa0XY19nq/hA7+Nrg+EissP5zgoYYeSphr85A==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-4.0.2.tgz",
+			"integrity": "sha512-bDjfbC29bwtlxQDmD5SNL296VVX68byaPQ2v2TVhSF57joMWNHUi/vVN0q+P9FHfnvJpUT41zhhfOznUn097EA==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-bubble": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-3.9.1.tgz",
-			"integrity": "sha512-tbd8ox/1GPl+zr+KyHQVV1bW88GE7OM6i4zql801YIlCDrl9wgTDdDFGIy9X7/cwTvTrCePhrfvdkUamXIribQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-4.0.2.tgz",
+			"integrity": "sha512-iTZmC+SafYM+8b4iXnyy7bACyWaU/UtF1QD1lvloN4pUFuLg71/RmudJFbvsM8s0H3nqYpRXxNDvtOOQxmqpGg==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-connect": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-3.9.1.tgz",
-			"integrity": "sha512-sq8YfUNsIORjXHzzW7/AJQtfi/qDqLnYG2qOSE1WOsog39MD30RzmiOloejOkfNeUdcGUcfsDgpUuL3UhzFUOA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-4.0.2.tgz",
+			"integrity": "sha512-Ov25f0w5821ov4HrWvDw+zQBwOD//8wsYO7TBa7M2N3kvZhIdiW5T/kVXa+AbqEIMCCbqvqXwhj6oxlRe764fQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+				"@tsparticles/canvas-utils": "4.0.2"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-destroy": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-destroy/-/interaction-external-destroy-4.0.2.tgz",
+			"integrity": "sha512-zmfg35KuAvUzFea8GO3cRax5NdwuGNPOXoIJoEkfeAQbtXthThJx0XVKyRWu8T3Mj5PDMY4wn2+SuT0YDkaOIw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-drag": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-drag/-/interaction-external-drag-4.0.2.tgz",
+			"integrity": "sha512-LZTtzFB1Sv0nGUGyqeFuZAaZm8wAW0fxZIyGiCk05hJN5dw31rYhB9psMb1OVJFrqRqBFbLZ5oe59Q/aguSp3g==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-grab": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-3.9.1.tgz",
-			"integrity": "sha512-QwXza+sMMWDaMiFxd8y2tJwUK6c+nNw554+/9+tEZeTTk2fCbB0IJ7p/TH6ZGWDL0vo2muK54Njv2fEey191ow==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-4.0.2.tgz",
+			"integrity": "sha512-q+mjFoAlRHoj4WtARjy2BNGqZzRHzbU2ONO9zeTO48mLwSlSkOyJdGbLn/SnElKG6c4g5C+Gdwp2co/DjScqVQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+				"@tsparticles/canvas-utils": "4.0.2"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-parallax": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-parallax/-/interaction-external-parallax-4.0.2.tgz",
+			"integrity": "sha512-5lWgMNCQVvEnsESOto1MqfStI7716MYK/8ZTIKhx3VhdQTjtRzy683/KJLWZZTkLAsQx1s+JcFuSLJsa9fskUA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-pause": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-3.9.1.tgz",
-			"integrity": "sha512-Gzv4/FeNir0U/tVM9zQCqV1k+IAgaFjDU3T30M1AeAsNGh/rCITV2wnT7TOGFkbcla27m4Yxa+Fuab8+8pzm+g==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-4.0.2.tgz",
+			"integrity": "sha512-eVZFoClNLJMlvLXKIInTU2nBtQUubCk3AxJTY6prsO7iDDCHREyt9YfT649SkhY/kMmrzuPwe7yNZ3ZDUR/VLw==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-push": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-3.9.1.tgz",
-			"integrity": "sha512-GvnWF9Qy4YkZdx+WJL2iy9IcgLvzOIu3K7aLYJFsQPaxT8d9TF8WlpoMlWKnJID6H5q4JqQuMRKRyWH8aAKyQw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-4.0.2.tgz",
+			"integrity": "sha512-9uTn8N/lRz0EQNBvKu4xoCYBySyQs2jGQnfC6ZERI1tK8QAXRKM+3Xp53eau6Ji0ZiOFoSGpT1ChsYG6GZKGog==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-remove": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-3.9.1.tgz",
-			"integrity": "sha512-yPThm4UDWejDOWW5Qc8KnnS2EfSo5VFcJUQDWc1+Wcj17xe7vdSoiwwOORM0PmNBzdDpSKQrte/gUnoqaUMwOA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-4.0.2.tgz",
+			"integrity": "sha512-eobnMHAiiZQZawRRK6bmsLEsiSrqyKr1RQXVEHHkr2Syiialw4+e1afLg/BwL9Rm7nDmYKwWXjlJ2ky36S//bA==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-repulse": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-3.9.1.tgz",
-			"integrity": "sha512-/LBppXkrMdvLHlEKWC7IykFhzrz+9nebT2fwSSFXK4plEBxDlIwnkDxd3FbVOAbnBvx4+L8+fbrEx+RvC8diAw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-4.0.2.tgz",
+			"integrity": "sha512-cPJDjj/qfQp8VyKEsgkniawlpfrv5hG69Mq9rWE7z5tQWbvi0NaPDriU1fFp4rc+DvAU1FwfFemqaFCw8yJUtQ==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-slow": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-3.9.1.tgz",
-			"integrity": "sha512-1ZYIR/udBwA9MdSCfgADsbDXKSFS0FMWuPWz7bm79g3sUxcYkihn+/hDhc6GXvNNR46V1ocJjrj0u6pAynS1KQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-4.0.2.tgz",
+			"integrity": "sha512-jVd1uSu/jrJNj7LYq5+/SK5vMlR7Syp6vhr1pjXx9Ov+VFROcPnNT1hgMcmD2eu/sWww+rnJjn+05f0CEkgoAA==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-external-trail": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-trail/-/interaction-external-trail-3.9.1.tgz",
-			"integrity": "sha512-Au0v2oiqfKTemI/4bzjD4dUXzIngB5Q2T4nJcMCYpP24uZfwZh5xTjUMH7gyJyyaRTdMl9IJrp8ySjyYbLfeGg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-trail/-/interaction-external-trail-4.0.2.tgz",
+			"integrity": "sha512-zTtqb8pfYyXDyu0EOxyxQ+euuLZJZiztWnc4SRjj/Zavdv5Sr5dUo8mtieF+1w0Z2pjN6WkqoFmnY961WpVdSA==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-particles-attract": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-3.9.1.tgz",
-			"integrity": "sha512-CYYYowJuGwRLUixQcSU/48PTKM8fCUYThe0hXwQ+yRMLAn053VHzL7NNZzKqEIeEyt5oJoy9KcvubjKWbzMBLQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-4.0.2.tgz",
+			"integrity": "sha512-a+4xLjE3apwtWgzJEmH0ENILu5/V072OkYIQ+DBn7mYpd3loz+JvngDiQgL2y3KbRQw/3qnCMgnGqt0+LiLZ0Q==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-particles-collisions": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-3.9.1.tgz",
-			"integrity": "sha512-ggGyjW/3v1yxvYW1IF1EMT15M6w31y5zfNNUPkqd/IXRNPYvm0Z0ayhp+FKmz70M5p0UxxPIQHTvAv9Jqnuj8w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-4.0.2.tgz",
+			"integrity": "sha512-Daw9x9ugAd5mTBtl56Tf2V63prNrn2jJLHgAt9E0vyeItQxIOlpgeEpT/oj8b4tnav1g0cx8ZP5RHRanjO8KNQ==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/interaction-particles-links": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-3.9.1.tgz",
-			"integrity": "sha512-MsLbMjy1vY5M5/hu/oa5OSRZAUz49H3+9EBMTIOThiX+a+vpl3sxc9AqNd9gMsPbM4WJlub8T6VBZdyvzez1Vg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-4.0.2.tgz",
+			"integrity": "sha512-fGrcaDUXE7ScwXBYzS33h61HJ7BIQi7aHXE/SL2NzyC7DkVee50X9XuqKOw51pNA3mM/Fk0xBL8PvoRjqf9tDA==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
-			}
-		},
-		"node_modules/@tsparticles/move-base": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/move-base/-/move-base-3.9.1.tgz",
-			"integrity": "sha512-X4huBS27d8srpxwOxliWPUt+NtCwY+8q/cx1DvQxyqmTA8VFCGpcHNwtqiN+9JicgzOvSuaORVqUgwlsc7h4pQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
-			}
-		},
-		"node_modules/@tsparticles/move-parallax": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/move-parallax/-/move-parallax-3.9.1.tgz",
-			"integrity": "sha512-whlOR0bVeyh6J/hvxf/QM3DqvNnITMiAQ0kro6saqSDItAVqg4pYxBfEsSOKq7EhjxNvfhhqR+pFMhp06zoCVA==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+				"@tsparticles/canvas-utils": "4.0.2"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/plugin-absorbers": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-3.9.1.tgz",
-			"integrity": "sha512-q9SQllpbPPgw1+euxHPYCFawOVUazQkkwnleiIgpYSiimlCyjIdwGnFPSNe1Sypzqmr2h6oOyX2vkK5ZVNEu8A==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-4.0.2.tgz",
+			"integrity": "sha512-3ox6FMzsvdkop2TsbzzGbAsyIfHl2f/KjXdPKrkSC+EHAwlKufqDB1xhVscdMH5SuhDCuDwlqsD1sxxrDv5lCQ==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
+			},
+			"peerDependenciesMeta": {
+				"@tsparticles/plugin-interactivity": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@tsparticles/plugin-easing-quad": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-3.9.1.tgz",
-			"integrity": "sha512-C2UJOca5MTDXKUTBXj30Kiqr5UyID+xrY/LxicVWWZPczQW2bBxbIbfq9ULvzGDwBTxE2rdvIB8YFKmDYO45qw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-4.0.2.tgz",
+			"integrity": "sha512-Zdntgznxe0SrtFfMSuwIDRLSi4iowiv3eiwcZJXsP2jPrxG7gR9PMG6DkbhmgU3P2BafRHh0mUzLY3NWOH9chQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -3177,23 +3710,29 @@
 				}
 			],
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/plugin-emitters": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-3.9.1.tgz",
-			"integrity": "sha512-h7opR8SoFWBmVHceDLJUerLENaPfkJSh2zQYvzmLj2L+V3VLS1QDgty+4QZVeZfqNROmgQw2eLFA5El1E0sqqw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-4.0.2.tgz",
+			"integrity": "sha512-j17LTe0n/UkW40GALIV9IvmGnDyQkxeUXFi1kUTCv0h9KMoHWjFO3nvcOEmWHqQuVfxT5+4F3WrR44gMwvsrNw==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2"
+			},
+			"peerDependenciesMeta": {
+				"@tsparticles/plugin-interactivity": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@tsparticles/plugin-emitters-shape-circle": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-3.9.1.tgz",
-			"integrity": "sha512-z+9MsAPWr++sNz6N6303rRDjusW0BIPhHY51E5eXGDcRdOqrESDs6y99AJ/6Kdb/PpibCIYjFY9jVi2JJADPRA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-4.0.2.tgz",
+			"integrity": "sha512-6ZUq/lXW397f96+TVV+7GA6oaRomuh3hAaHSu4KwVgj7JkcVF5rNuIHL5eOaFIqIxlR/QaL3/mcR7MMM7W0CeA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3209,15 +3748,15 @@
 				}
 			],
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1",
-				"@tsparticles/plugin-emitters": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-emitters": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/plugin-emitters-shape-square": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-3.9.1.tgz",
-			"integrity": "sha512-dhA1c7FKs19B8lgTf25OTA3JoptNA+rjorsqCFuY1BZDI8g9E8DNqikUge14/W7nZN96+98hY+ghxSl4K2YsgA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-4.0.2.tgz",
+			"integrity": "sha512-4zFRWAV9Jt4VkwPaoopJNuLHf8UWIiQ0stdiwMw5agGOFfeBjSVfWqUEAxKhuOdNst3k50X44tmhDpESLmio4A==",
 			"funding": [
 				{
 					"type": "github",
@@ -3233,15 +3772,15 @@
 				}
 			],
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1",
-				"@tsparticles/plugin-emitters": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/plugin-emitters": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/plugin-hex-color": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-3.9.1.tgz",
-			"integrity": "sha512-vZgZ12AjUicJvk7AX4K2eAmKEQX/D1VEjEPFhyjbgI7A65eX72M465vVKIgNA6QArLZ1DLs7Z787LOE6GOBWsg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-4.0.2.tgz",
+			"integrity": "sha512-wobR2XD42kLHt2wgj2Hd5c8/urcBgIg2Cs+2zo5j8GQkpY3Na0ofPrpojQXrC663Q8lhaC1EJ5spEM8wT3EzEA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3257,14 +3796,14 @@
 				}
 			],
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/plugin-hsl-color": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-3.9.1.tgz",
-			"integrity": "sha512-jJd1iGgRwX6eeNjc1zUXiJivaqC5UE+SC2A3/NtHwwoQrkfxGWmRHOsVyLnOBRcCPgBp/FpdDe6DIDjCMO715w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-4.0.2.tgz",
+			"integrity": "sha512-hCG+pGkqS+ucibQ2RGY3t/Uwh+llbSfRwf9qidDI9emlb3Mx2GoqGR15h2wMhEvNxf96I8G12hN1QFA3V9n1EA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3280,14 +3819,32 @@
 				}
 			],
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
+			}
+		},
+		"node_modules/@tsparticles/plugin-interactivity": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-interactivity/-/plugin-interactivity-4.0.2.tgz",
+			"integrity": "sha512-e3RczVWDh0fZRSu8s1YA2QIpGIPdbQgUwbgrUiyNdKHgUTyOHmWTOKcnKMrRpwtt6PD1n3cR5ed8n6NUomLaGg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
+			}
+		},
+		"node_modules/@tsparticles/plugin-move": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-move/-/plugin-move-4.0.2.tgz",
+			"integrity": "sha512-rO7ITxNNGd+lZ6TiScXz5vhkpkfQL7hoXEdQZ8kKCgPEXpJX23GVLtAP9jNHSmzYQgFOmxoktuggWpqzdqoFhA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/plugin-rgb-color": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-3.9.1.tgz",
-			"integrity": "sha512-SBxk7f1KBfXeTnnklbE2Hx4jBgh6I6HOtxb+Os1gTp0oaghZOkWcCD2dP4QbUu7fVNCMOcApPoMNC8RTFcy9wQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-4.0.2.tgz",
+			"integrity": "sha512-/6VaPUTdhbV+1TMYBJ+1NhAsKaIasH0rSKVTUUWzwFDdFIl93NblGsjwZgk/7WcMEbxJ4j64nR/r8YjgUAIGSA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3303,86 +3860,92 @@
 				}
 			],
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/shape-circle": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-3.9.1.tgz",
-			"integrity": "sha512-DqZFLjbuhVn99WJ+A9ajz9YON72RtCcvubzq6qfjFmtwAK7frvQeb6iDTp6Ze9FUipluxVZWVRG4vWTxi2B+/g==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-4.0.2.tgz",
+			"integrity": "sha512-b64si1QRfj1wL27GIgdiKJzJb/iDuMnGRiEnuvnwxI7gL67qTjaDRmCS5+16QBqfrttcm0mXp+JMqFsCmcMD+Q==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/shape-emoji": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-3.9.1.tgz",
-			"integrity": "sha512-ifvY63usuT+hipgVHb8gelBHSeF6ryPnMxAAEC1RGHhhXfpSRWMtE6ybr+pSsYU52M3G9+TF84v91pSwNrb9ZQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-4.0.2.tgz",
+			"integrity": "sha512-UkkfkcvCayzBZO5wemOZ+n1A/StZ1xQi+TRvoNm4CbFU3Qan3VsrXQl6rQyrM84rDUCJ9Qw+/d7ZoZoQ3Kujuw==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+				"@tsparticles/canvas-utils": "4.0.2"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/shape-image": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-3.9.1.tgz",
-			"integrity": "sha512-fCA5eme8VF3oX8yNVUA0l2SLDKuiZObkijb0z3Ky0qj1HUEVlAuEMhhNDNB9E2iELTrWEix9z7BFMePp2CC7AA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-4.0.2.tgz",
+			"integrity": "sha512-rqsxPRGlwFu+AH/xdok+tBpi6rgKBUSiMHjlU4U86JZ7tkW+aLjtayovpd6zPep9N9SB3xrAz2rYWzbQOiUzMg==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/shape-line": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-3.9.1.tgz",
-			"integrity": "sha512-wT8NSp0N9HURyV05f371cHKcNTNqr0/cwUu6WhBzbshkYGy1KZUP9CpRIh5FCrBpTev34mEQfOXDycgfG0KiLQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-4.0.2.tgz",
+			"integrity": "sha512-jpKPn8r3DrVyiXOjdcEU7Qd0ZN1fthJ6Pd77pEeXqTt7uyFyhc9k6ZufriJdpv4pwlB6825HeFQzQ3ksWChn3w==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/shape-polygon": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-3.9.1.tgz",
-			"integrity": "sha512-dA77PgZdoLwxnliH6XQM/zF0r4jhT01pw5y7XTeTqws++hg4rTLV9255k6R6eUqKq0FPSW1/WBsBIl7q/MmrqQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-4.0.2.tgz",
+			"integrity": "sha512-uEp05LzzIiST510v+coLWVGbiukR+AHx77qL/kuCk2Bhv/VSneob2qV2xi6tlAaOy5pqLWYlbL5od6XoGayRzg==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/shape-square": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-3.9.1.tgz",
-			"integrity": "sha512-DKGkDnRyZrAm7T2ipqNezJahSWs6xd9O5LQLe5vjrYm1qGwrFxJiQaAdlb00UNrexz1/SA7bEoIg4XKaFa7qhQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-4.0.2.tgz",
+			"integrity": "sha512-aqbzmf0GWTOpZQJ4w266OhNuCyK1NMUpPEh0gSB5zdXUmPozEDGtsMr5xTdvoCdd9iIfsconIAmG0Cf3tSr3Ng==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/shape-star": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-3.9.1.tgz",
-			"integrity": "sha512-kdMJpi8cdeb6vGrZVSxTG0JIjCwIenggqk0EYeKAwtOGZFBgL7eHhF2F6uu1oq8cJAbXPujEoabnLsz6mW8XaA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-4.0.2.tgz",
+			"integrity": "sha512-sRSANDemSoZFyq9ORkgBw+2Frq3zszN8jgtz17nNFmf0Ad2yUvThtgefa/vU1NTV+f4TgV0g448CFw6k/xB4iA==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/shape-text": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-3.9.1.tgz",
-			"integrity": "sha512-oNsLHI0lGkIXoUw3W598iwd7dtoHCDrwpwJRGnQzgfk6T5a9dCpSD5vDeQN89lr3BUbVui4lhxq+/TyC64oAqA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-4.0.2.tgz",
+			"integrity": "sha512-YtzMcVWcdRPpu/xZ6kJAQug1AAdkUhV21mmOuAiXAesVrDIFWgNt9xlkpiH8VD61bQXRe87vIKcOXlD5WLxDaA==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+				"@tsparticles/canvas-utils": "4.0.2"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/slim": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-3.9.1.tgz",
-			"integrity": "sha512-CL5cDmADU7sDjRli0So+hY61VMbdroqbArmR9Av+c1Fisa5ytr6QD7Jv62iwU2S6rvgicEe9OyRmSy5GIefwZw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-4.0.2.tgz",
+			"integrity": "sha512-lxyijpUAAY+6TETDKstlaQuZOwZNJbBTDV6PyjFOsFs5bvrajPhs3TF5tj0PRUW8YGltc0nfZwDS5q8NwtUfVA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3399,140 +3962,133 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/basic": "3.9.1",
-				"@tsparticles/engine": "3.9.1",
-				"@tsparticles/interaction-external-attract": "3.9.1",
-				"@tsparticles/interaction-external-bounce": "3.9.1",
-				"@tsparticles/interaction-external-bubble": "3.9.1",
-				"@tsparticles/interaction-external-connect": "3.9.1",
-				"@tsparticles/interaction-external-grab": "3.9.1",
-				"@tsparticles/interaction-external-pause": "3.9.1",
-				"@tsparticles/interaction-external-push": "3.9.1",
-				"@tsparticles/interaction-external-remove": "3.9.1",
-				"@tsparticles/interaction-external-repulse": "3.9.1",
-				"@tsparticles/interaction-external-slow": "3.9.1",
-				"@tsparticles/interaction-particles-attract": "3.9.1",
-				"@tsparticles/interaction-particles-collisions": "3.9.1",
-				"@tsparticles/interaction-particles-links": "3.9.1",
-				"@tsparticles/move-parallax": "3.9.1",
-				"@tsparticles/plugin-easing-quad": "3.9.1",
-				"@tsparticles/shape-emoji": "3.9.1",
-				"@tsparticles/shape-image": "3.9.1",
-				"@tsparticles/shape-line": "3.9.1",
-				"@tsparticles/shape-polygon": "3.9.1",
-				"@tsparticles/shape-square": "3.9.1",
-				"@tsparticles/shape-star": "3.9.1",
-				"@tsparticles/updater-life": "3.9.1",
-				"@tsparticles/updater-rotate": "3.9.1",
-				"@tsparticles/updater-stroke-color": "3.9.1"
-			}
-		},
-		"node_modules/@tsparticles/updater-color": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-color/-/updater-color-3.9.1.tgz",
-			"integrity": "sha512-XGWdscrgEMA8L5E7exsE0f8/2zHKIqnTrZymcyuFBw2DCB6BIV+5z6qaNStpxrhq3DbIxxhqqcybqeOo7+Alpg==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+				"@tsparticles/basic": "4.0.2",
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/interaction-external-attract": "4.0.2",
+				"@tsparticles/interaction-external-bounce": "4.0.2",
+				"@tsparticles/interaction-external-bubble": "4.0.2",
+				"@tsparticles/interaction-external-connect": "4.0.2",
+				"@tsparticles/interaction-external-destroy": "4.0.2",
+				"@tsparticles/interaction-external-grab": "4.0.2",
+				"@tsparticles/interaction-external-parallax": "4.0.2",
+				"@tsparticles/interaction-external-pause": "4.0.2",
+				"@tsparticles/interaction-external-push": "4.0.2",
+				"@tsparticles/interaction-external-remove": "4.0.2",
+				"@tsparticles/interaction-external-repulse": "4.0.2",
+				"@tsparticles/interaction-external-slow": "4.0.2",
+				"@tsparticles/interaction-particles-attract": "4.0.2",
+				"@tsparticles/interaction-particles-collisions": "4.0.2",
+				"@tsparticles/interaction-particles-links": "4.0.2",
+				"@tsparticles/plugin-easing-quad": "4.0.2",
+				"@tsparticles/plugin-interactivity": "4.0.2",
+				"@tsparticles/shape-emoji": "4.0.2",
+				"@tsparticles/shape-image": "4.0.2",
+				"@tsparticles/shape-line": "4.0.2",
+				"@tsparticles/shape-polygon": "4.0.2",
+				"@tsparticles/shape-square": "4.0.2",
+				"@tsparticles/shape-star": "4.0.2",
+				"@tsparticles/updater-life": "4.0.2",
+				"@tsparticles/updater-paint": "4.0.2",
+				"@tsparticles/updater-rotate": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-destroy": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-3.9.1.tgz",
-			"integrity": "sha512-MjMzEhZwCQIbxO6ZRM0eXsHVwmlXuUqwC43WCPZCpjhK3AJrMu3KR4xsJieFTWIbVNguAvbgoTB10FfJOUU5VA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-4.0.2.tgz",
+			"integrity": "sha512-WLE+UtHU1PAr4dp0h9aNSmrr/+bEQbvUkIBXh1Zv1LoE3FYhBLyfoz+0BcIOr8atD8u2hOUvtyLBewl4L1hkFA==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-life": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-3.9.1.tgz",
-			"integrity": "sha512-Oi8aF2RIwMMsjssUkCB6t3PRpENHjdZf6cX92WNfAuqXtQphr3OMAkYFJFWkvyPFK22AVy3p/cFt6KE5zXxwAA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-4.0.2.tgz",
+			"integrity": "sha512-ezqVL8aGjY1vsYtmVujxQL2FBCfIXFADwoCpyAnHaZ6Wb1YZTyYx+cCbitcHy53L99L9RSaJELe8WuH8K2P/tQ==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-opacity": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-3.9.1.tgz",
-			"integrity": "sha512-w778LQuRZJ+IoWzeRdrGykPYSSaTeWfBvLZ2XwYEkh/Ss961InOxZKIpcS6i5Kp/Zfw0fS1ZAuqeHwuj///Osw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-4.0.2.tgz",
+			"integrity": "sha512-TLvjO2aoGGri4qToNwcbhEnklXow8ePE7r6wrhsr6UQUisuV2WOgVfY8qazy/wQ/VITf/UhFpeAVUUxxB7LvUw==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-out-modes": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-3.9.1.tgz",
-			"integrity": "sha512-cKQEkAwbru+hhKF+GTsfbOvuBbx2DSB25CxOdhtW2wRvDBoCnngNdLw91rs+0Cex4tgEeibkebrIKFDDE6kELg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-4.0.2.tgz",
+			"integrity": "sha512-9Sdg1J/1IudnbpxzKsyhfnNzApBer/T9wFxf4q9QAMNsYMmHacBMMH5Dh0On4o1SWY5v2m2cnmivyouAOf8y0Q==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
+			}
+		},
+		"node_modules/@tsparticles/updater-paint": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-paint/-/updater-paint-4.0.2.tgz",
+			"integrity": "sha512-McH84yJvnlldpf8AwIjAe/oiNYyrNQrWGM8657Q7JptWSFkElPYM4Ph7MtNXlvAlvmZ3OIJld+JK+eHXWa4Crg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-roll": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-3.9.1.tgz",
-			"integrity": "sha512-zl4JeM3gUBJ0uttmIsond3lrZ3f3AkItFeS0Lhj/7jiCKfUoRyyOMrcBk8R1AhW7lI+7ko1iBs3jhO0jnxz9vg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-4.0.2.tgz",
+			"integrity": "sha512-UuxKlEmrC9x/ID+KP0j1k/DsCzmZHUFgZ6C0cSbiIEf3roUXbFo6/u37XzpFE5pq6qlTqCRiI4+EJKoT6UaFtQ==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-rotate": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-3.9.1.tgz",
-			"integrity": "sha512-9BfKaGfp28JN82MF2qs6Ae/lJr9EColMfMTHqSKljblwbpVDHte4umuwKl3VjbRt87WD9MGtla66NTUYl+WxuQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-4.0.2.tgz",
+			"integrity": "sha512-SeCtW4MSqeQFVULOolevVahGwvugp5o/vcXBcCunULSNrivEluZ22GlLfvMMvajItb2UmK16NjHPZy4qP7ALyw==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-size": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-3.9.1.tgz",
-			"integrity": "sha512-3NSVs0O2ApNKZXfd+y/zNhTXSFeG1Pw4peI8e6z/q5+XLbmue9oiEwoPy/tQLaark3oNj3JU7Q903ZijPyXSzw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-4.0.2.tgz",
+			"integrity": "sha512-CIfmy8jimvo8C6HWJgLxy70v/L1vVvZ9zk4eFcf8AcLEykqEH6vXTO1xwm/XlZ5L5RhSlFrmM14pqYA2rWQVqw==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
-			}
-		},
-		"node_modules/@tsparticles/updater-stroke-color": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-stroke-color/-/updater-stroke-color-3.9.1.tgz",
-			"integrity": "sha512-3x14+C2is9pZYTg9T2TiA/aM1YMq4wLdYaZDcHm3qO30DZu5oeQq0rm/6w+QOGKYY1Z3Htg9rlSUZkhTHn7eDA==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-tilt": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-3.9.1.tgz",
-			"integrity": "sha512-PB2yaoyXRmSk4iIVgjtRrzOxXMK9mjeAQHIJGtT4faq46Z8cbIIEFgjTwqrUV8qOrNg/h4sm5NE/s0qsTYjp1Q==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-4.0.2.tgz",
+			"integrity": "sha512-EvUE9IvBLq1OqSfNlxJl87Q7YCSnHy3Tz1bOpy1MjPr7K0a/j9n6RqowNjEqqOBXsXtThUmDmtyI9Bmnbq//SA==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-twinkle": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-3.9.1.tgz",
-			"integrity": "sha512-xgTcYr6LmP44IPIBeQmEExN2Y5Nfl3ikmC08eOh5nZy/ta6ORP+JTsprrnfuv/O2DwTyoqFLkZ16hZfkdc1yOQ==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-4.0.2.tgz",
+			"integrity": "sha512-ll8RUyEBRiA9eGiY2hyQ6duIG4Ao5uUSZN50oKoEnDLHic1jov6HrOikqvEBCgaSo949uZZUGGo6xg+nhOYlOA==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tsparticles/updater-wobble": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-3.9.1.tgz",
-			"integrity": "sha512-c99Ogy9q4QWO+zsDXol0UnpUwZiY2UucFb8ltuDv9AlbGUeprygoub8jhgT5pEDv+GdzWOJGSgq7rfgv9cHBrg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-4.0.2.tgz",
+			"integrity": "sha512-1BaprT1jkCsSNRHby8DOSdi5cK7lsP50DkJjqG+SwjOQemj7JeGsPcedtrVxoFSLb8CtD7Coa86qua9mc0WrNw==",
 			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/engine": "3.9.1"
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.2"
 			}
 		},
 		"node_modules/@tweenjs/tween.js": {
@@ -4518,6 +5074,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4535,6 +5094,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4552,6 +5114,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4569,6 +5134,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4586,6 +5154,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4603,6 +5174,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4620,6 +5194,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4643,6 +5220,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4666,6 +5246,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4689,6 +5272,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4712,6 +5298,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4735,6 +5324,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -6177,9 +6769,9 @@
 			"license": "MIT"
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.4",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.4.tgz",
-			"integrity": "sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==",
+			"version": "3.4.5",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.5.tgz",
+			"integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
@@ -6260,6 +6852,48 @@
 				"docs",
 				"benchmarks"
 			]
+		},
+		"node_modules/esbuild": {
+			"version": "0.27.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.3",
+				"@esbuild/android-arm": "0.27.3",
+				"@esbuild/android-arm64": "0.27.3",
+				"@esbuild/android-x64": "0.27.3",
+				"@esbuild/darwin-arm64": "0.27.3",
+				"@esbuild/darwin-x64": "0.27.3",
+				"@esbuild/freebsd-arm64": "0.27.3",
+				"@esbuild/freebsd-x64": "0.27.3",
+				"@esbuild/linux-arm": "0.27.3",
+				"@esbuild/linux-arm64": "0.27.3",
+				"@esbuild/linux-ia32": "0.27.3",
+				"@esbuild/linux-loong64": "0.27.3",
+				"@esbuild/linux-mips64el": "0.27.3",
+				"@esbuild/linux-ppc64": "0.27.3",
+				"@esbuild/linux-riscv64": "0.27.3",
+				"@esbuild/linux-s390x": "0.27.3",
+				"@esbuild/linux-x64": "0.27.3",
+				"@esbuild/netbsd-arm64": "0.27.3",
+				"@esbuild/netbsd-x64": "0.27.3",
+				"@esbuild/openbsd-arm64": "0.27.3",
+				"@esbuild/openbsd-x64": "0.27.3",
+				"@esbuild/openharmony-arm64": "0.27.3",
+				"@esbuild/sunos-x64": "0.27.3",
+				"@esbuild/win32-arm64": "0.27.3",
+				"@esbuild/win32-ia32": "0.27.3",
+				"@esbuild/win32-x64": "0.27.3"
+			}
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -7797,6 +8431,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7818,6 +8455,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7839,6 +8479,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7860,6 +8503,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -7995,9 +8641,9 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "11.3.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-			"integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -9521,16 +10167,6 @@
 				}
 			}
 		},
-		"node_modules/postcss-load-config/node_modules/yaml": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/postcss-safe-parser": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
@@ -10929,9 +11565,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsparticles": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-3.9.1.tgz",
-			"integrity": "sha512-Y780IGSL4qjkZj7+fI92PV/cziHqLR/s6nnYri4K6vH3NQRmDK5D6pfskDO8T4Y96ChCWHY3uxPtOb/hKQ83Qg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-4.0.2.tgz",
+			"integrity": "sha512-L5EU2tKqFOqrefL9njwVys1busOPMy8kdmnZeIz6G3l5s/3pL74+OOvgqyAgxIy2LTEeGgX3ZRTTx2shquKsag==",
 			"funding": [
 				{
 					"type": "github",
@@ -10948,19 +11584,20 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "3.9.1",
-				"@tsparticles/interaction-external-trail": "3.9.1",
-				"@tsparticles/plugin-absorbers": "3.9.1",
-				"@tsparticles/plugin-emitters": "3.9.1",
-				"@tsparticles/plugin-emitters-shape-circle": "3.9.1",
-				"@tsparticles/plugin-emitters-shape-square": "3.9.1",
-				"@tsparticles/shape-text": "3.9.1",
-				"@tsparticles/slim": "3.9.1",
-				"@tsparticles/updater-destroy": "3.9.1",
-				"@tsparticles/updater-roll": "3.9.1",
-				"@tsparticles/updater-tilt": "3.9.1",
-				"@tsparticles/updater-twinkle": "3.9.1",
-				"@tsparticles/updater-wobble": "3.9.1"
+				"@tsparticles/engine": "4.0.2",
+				"@tsparticles/interaction-external-drag": "4.0.2",
+				"@tsparticles/interaction-external-trail": "4.0.2",
+				"@tsparticles/plugin-absorbers": "4.0.2",
+				"@tsparticles/plugin-emitters": "4.0.2",
+				"@tsparticles/plugin-emitters-shape-circle": "4.0.2",
+				"@tsparticles/plugin-emitters-shape-square": "4.0.2",
+				"@tsparticles/shape-text": "4.0.2",
+				"@tsparticles/slim": "4.0.2",
+				"@tsparticles/updater-destroy": "4.0.2",
+				"@tsparticles/updater-roll": "4.0.2",
+				"@tsparticles/updater-tilt": "4.0.2",
+				"@tsparticles/updater-twinkle": "4.0.2",
+				"@tsparticles/updater-wobble": "4.0.2"
 			}
 		},
 		"node_modules/tweakpane": {
@@ -11856,490 +12493,6 @@
 				}
 			}
 		},
-		"node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/android-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/android-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/android-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/linux-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/@esbuild/win32-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/wrangler/node_modules/esbuild": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"bin": {
-				"esbuild": "bin/esbuild"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.3",
-				"@esbuild/android-arm": "0.27.3",
-				"@esbuild/android-arm64": "0.27.3",
-				"@esbuild/android-x64": "0.27.3",
-				"@esbuild/darwin-arm64": "0.27.3",
-				"@esbuild/darwin-x64": "0.27.3",
-				"@esbuild/freebsd-arm64": "0.27.3",
-				"@esbuild/freebsd-x64": "0.27.3",
-				"@esbuild/linux-arm": "0.27.3",
-				"@esbuild/linux-arm64": "0.27.3",
-				"@esbuild/linux-ia32": "0.27.3",
-				"@esbuild/linux-loong64": "0.27.3",
-				"@esbuild/linux-mips64el": "0.27.3",
-				"@esbuild/linux-ppc64": "0.27.3",
-				"@esbuild/linux-riscv64": "0.27.3",
-				"@esbuild/linux-s390x": "0.27.3",
-				"@esbuild/linux-x64": "0.27.3",
-				"@esbuild/netbsd-arm64": "0.27.3",
-				"@esbuild/netbsd-x64": "0.27.3",
-				"@esbuild/openbsd-arm64": "0.27.3",
-				"@esbuild/openbsd-x64": "0.27.3",
-				"@esbuild/openharmony-arm64": "0.27.3",
-				"@esbuild/sunos-x64": "0.27.3",
-				"@esbuild/win32-arm64": "0.27.3",
-				"@esbuild/win32-ia32": "0.27.3",
-				"@esbuild/win32-x64": "0.27.3"
-			}
-		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -12431,6 +12584,16 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/yargs": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -98,10 +98,10 @@
 		"@stripe/stripe-js": "^9.5.0",
 		"@threlte/core": "^8.5.14",
 		"@threlte/extras": "^9.18.0",
-		"@tsparticles/engine": "^3.0.0",
-		"@tsparticles/interaction-external-trail": "^3.0.0",
-		"@tsparticles/shape-text": "^3.0.0",
-		"@tsparticles/slim": "^3.0.0",
+		"@tsparticles/engine": "^4.0.2",
+		"@tsparticles/interaction-external-trail": "^4.0.2",
+		"@tsparticles/shape-text": "^4.0.2",
+		"@tsparticles/slim": "^4.0.2",
 		"apexcharts": "^5.12.0",
 		"arctic": "^3.7.0",
 		"cookie": "^1.1.1",
@@ -116,6 +116,6 @@
 		"stripe": "^22.1.1",
 		"three": "^0.184.0",
 		"tippy.js": "^6.3.7",
-		"tsparticles": "^3.0.0"
+		"tsparticles": "^4.0.2"
 	}
 }

--- a/webapp/src/lib/client/particleConfig.js
+++ b/webapp/src/lib/client/particleConfig.js
@@ -135,7 +135,7 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							weight: '400',
 							particles: {
 								paint: { color: { value: '#00FF9E' } }, // Green for positive
-								size: { value: 24 },
+								size: { value: 48 },
 								links: {
 									color: { value: '#ffffff' } // white lines
 								}
@@ -148,7 +148,7 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							weight: '400',
 							particles: {
 								paint: { color: { value: '#FF0061' } }, // Red for negative
-								size: { value: 24 },
+								size: { value: 48 },
 								links: {
 									color: { value: '#ffffff' } // white lines
 								}
@@ -223,7 +223,7 @@ export const createErrorParticleConfig = (overrides = {}) => {
 			weight: '400',
 			particles: {
 				paint: { color: { value: '#22c55e' } }, // Green
-				size: { value: 24 }
+				size: { value: 48 }
 			}
 		},
 		{
@@ -233,7 +233,7 @@ export const createErrorParticleConfig = (overrides = {}) => {
 			weight: '400',
 			particles: {
 				paint: { color: { value: '#FF0061' } }, // Red
-				size: { value: 24 }
+				size: { value: 48 }
 			}
 		}
 	];
@@ -256,7 +256,7 @@ export const createAuthParticleConfig = (overrides = {}) => {
 			weight: '400',
 			particles: {
 				paint: { color: { value: '#22c55e' } }, // Green
-				size: { value: 24 }
+				size: { value: 48 }
 			}
 		},
 		{
@@ -266,7 +266,7 @@ export const createAuthParticleConfig = (overrides = {}) => {
 			weight: '400',
 			particles: {
 				paint: { color: { value: '#fbbf24' } }, // Yellow/amber
-				size: { value: 24 }
+				size: { value: 48 }
 			}
 		}
 	];

--- a/webapp/src/lib/client/particleConfig.js
+++ b/webapp/src/lib/client/particleConfig.js
@@ -134,7 +134,7 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							value: generatePercentageValues(50, true), // Positive percentages
 							weight: '400',
 							particles: {
-								color: { value: '#00FF9E' }, // Green for positive
+								paint: { color: { value: '#00FF9E' } }, // Green for positive
 								size: { value: 24 },
 								links: {
 									color: { value: '#ffffff' } // white lines
@@ -147,7 +147,7 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							value: generatePercentageValues(50, false), // Negative percentages
 							weight: '400',
 							particles: {
-								color: { value: '#FF0061' }, // Red for negative
+								paint: { color: { value: '#FF0061' } }, // Red for negative
 								size: { value: 24 },
 								links: {
 									color: { value: '#ffffff' } // white lines
@@ -222,7 +222,7 @@ export const createErrorParticleConfig = (overrides = {}) => {
 			value: ['404', '404', '404'],
 			weight: '400',
 			particles: {
-				color: { value: '#22c55e' }, // Green
+				paint: { color: { value: '#22c55e' } }, // Green
 				size: { value: 24 }
 			}
 		},
@@ -232,7 +232,7 @@ export const createErrorParticleConfig = (overrides = {}) => {
 			value: ['ERROR', 'ERROR'],
 			weight: '400',
 			particles: {
-				color: { value: '#FF0061' }, // Red
+				paint: { color: { value: '#FF0061' } }, // Red
 				size: { value: 24 }
 			}
 		}
@@ -255,7 +255,7 @@ export const createAuthParticleConfig = (overrides = {}) => {
 			value: ['AUTH', 'AUTH', 'AUTH'],
 			weight: '400',
 			particles: {
-				color: { value: '#22c55e' }, // Green
+				paint: { color: { value: '#22c55e' } }, // Green
 				size: { value: 24 }
 			}
 		},
@@ -265,7 +265,7 @@ export const createAuthParticleConfig = (overrides = {}) => {
 			value: ['LOGIN', 'LOGIN'],
 			weight: '400',
 			particles: {
-				color: { value: '#fbbf24' }, // Yellow/amber
+				paint: { color: { value: '#fbbf24' } }, // Yellow/amber
 				size: { value: 24 }
 			}
 		}
@@ -292,3 +292,34 @@ function deepMerge(target, source) {
 
 	return result;
 }
+
+/*
+ * EXAMPLE: Creating custom particle configurations
+ *
+ * To add new particle effects, follow this pattern:
+ *
+ * export const createCustomParticleConfig = (overrides = {}) => {
+ *   const config = {
+ *     ...baseConfig,
+ *     particles: {
+ *       ...baseConfig.particles,
+ *       // Custom particle settings
+ *       shape: {
+ *         type: 'circle', // or 'text', 'star', etc.
+ *         options: { ... }
+ *       },
+ *       color: { value: '#custom-color' },
+ *       move: {
+ *         ...baseConfig.particles.move,
+ *         direction: 'custom-direction'
+ *       }
+ *     }
+ *   };
+ *
+ *   return deepMerge(config, overrides);
+ * };
+ *
+ * SECURITY NOTE: This module uses crypto.getRandomValues() for all random number
+ * generation. If you create custom particle configs that need randomness, consider
+ * using the same approach for consistency and security best practices.
+ */

--- a/webapp/src/lib/client/particleConfig.js
+++ b/webapp/src/lib/client/particleConfig.js
@@ -135,7 +135,10 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							weight: '400',
 							particles: {
 								color: { value: '#00FF9E' }, // Green for positive
-								size: { value: 8 }
+								size: { value: 8 },
+								links: {
+									color: { value: '#ffffff' } // white lines
+								}
 							}
 						},
 						{
@@ -145,7 +148,10 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							weight: '400',
 							particles: {
 								color: { value: '#FF0061' }, // Red for negative
-								size: { value: 8 }
+								size: { value: 8 },
+								links: {
+									color: { value: '#ffffff' } // white lines
+								}
 							}
 						}
 					]

--- a/webapp/src/lib/client/particleConfig.js
+++ b/webapp/src/lib/client/particleConfig.js
@@ -135,7 +135,7 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							weight: '400',
 							particles: {
 								color: { value: '#00FF9E' }, // Green for positive
-								size: { value: 8 },
+								size: { value: 24 },
 								links: {
 									color: { value: '#ffffff' } // white lines
 								}
@@ -148,7 +148,7 @@ export const createFinancialParticleConfig = (overrides = {}) => {
 							weight: '400',
 							particles: {
 								color: { value: '#FF0061' }, // Red for negative
-								size: { value: 8 },
+								size: { value: 24 },
 								links: {
 									color: { value: '#ffffff' } // white lines
 								}
@@ -223,7 +223,7 @@ export const createErrorParticleConfig = (overrides = {}) => {
 			weight: '400',
 			particles: {
 				color: { value: '#22c55e' }, // Green
-				size: { value: 12 }
+				size: { value: 24 }
 			}
 		},
 		{
@@ -233,7 +233,7 @@ export const createErrorParticleConfig = (overrides = {}) => {
 			weight: '400',
 			particles: {
 				color: { value: '#FF0061' }, // Red
-				size: { value: 12 }
+				size: { value: 24 }
 			}
 		}
 	];
@@ -256,7 +256,7 @@ export const createAuthParticleConfig = (overrides = {}) => {
 			weight: '400',
 			particles: {
 				color: { value: '#22c55e' }, // Green
-				size: { value: 12 }
+				size: { value: 24 }
 			}
 		},
 		{
@@ -266,7 +266,7 @@ export const createAuthParticleConfig = (overrides = {}) => {
 			weight: '400',
 			particles: {
 				color: { value: '#fbbf24' }, // Yellow/amber
-				size: { value: 12 }
+				size: { value: 24 }
 			}
 		}
 	];
@@ -292,34 +292,3 @@ function deepMerge(target, source) {
 
 	return result;
 }
-
-/*
- * EXAMPLE: Creating custom particle configurations
- *
- * To add new particle effects, follow this pattern:
- *
- * export const createCustomParticleConfig = (overrides = {}) => {
- *   const config = {
- *     ...baseConfig,
- *     particles: {
- *       ...baseConfig.particles,
- *       // Custom particle settings
- *       shape: {
- *         type: 'circle', // or 'text', 'star', etc.
- *         options: { ... }
- *       },
- *       color: { value: '#custom-color' },
- *       move: {
- *         ...baseConfig.particles.move,
- *         direction: 'custom-direction'
- *       }
- *     }
- *   };
- *
- *   return deepMerge(config, overrides);
- * };
- *
- * SECURITY NOTE: This module uses crypto.getRandomValues() for all random number
- * generation. If you create custom particle configs that need randomness, consider
- * using the same approach for consistency and security best practices.
- */

--- a/webapp/tests/lib/client/particleConfig.test.js
+++ b/webapp/tests/lib/client/particleConfig.test.js
@@ -66,11 +66,13 @@ describe('ParticleConfig', () => {
 			// Check positive percentages (green)
 			const positiveText = config.particles.shape.options.text[0];
 			expect(positiveText.particles.color).toEqual({ value: '#00FF9E' });
+			expect(positiveText.particles.links.color).toEqual({ value: '#ffffff' });
 			expect(positiveText.value).toHaveLength(50);
 
 			// Check negative percentages (red)
 			const negativeText = config.particles.shape.options.text[1];
 			expect(negativeText.particles.color).toEqual({ value: '#FF0061' });
+			expect(negativeText.particles.links.color).toEqual({ value: '#ffffff' });
 			expect(negativeText.value).toHaveLength(50);
 		});
 

--- a/webapp/tests/lib/client/particleConfig.test.js
+++ b/webapp/tests/lib/client/particleConfig.test.js
@@ -65,13 +65,13 @@ describe('ParticleConfig', () => {
 
 			// Check positive percentages (green)
 			const positiveText = config.particles.shape.options.text[0];
-			expect(positiveText.particles.color).toEqual({ value: '#00FF9E' });
+			expect(positiveText.particles.paint.color).toEqual({ value: '#00FF9E' });
 			expect(positiveText.particles.links.color).toEqual({ value: '#ffffff' });
 			expect(positiveText.value).toHaveLength(50);
 
 			// Check negative percentages (red)
 			const negativeText = config.particles.shape.options.text[1];
-			expect(negativeText.particles.color).toEqual({ value: '#FF0061' });
+			expect(negativeText.particles.paint.color).toEqual({ value: '#FF0061' });
 			expect(negativeText.particles.links.color).toEqual({ value: '#ffffff' });
 			expect(negativeText.value).toHaveLength(50);
 		});
@@ -107,12 +107,12 @@ describe('ParticleConfig', () => {
 
 			// Check 404 text (green)
 			const error404Text = config.particles.shape.options.text[0];
-			expect(error404Text.particles.color).toEqual({ value: '#22c55e' });
+			expect(error404Text.particles.paint.color).toEqual({ value: '#22c55e' });
 			expect(error404Text.value).toEqual(['404', '404', '404']);
 
 			// Check ERROR text (red)
 			const errorText = config.particles.shape.options.text[1];
-			expect(errorText.particles.color).toEqual({ value: '#FF0061' });
+			expect(errorText.particles.paint.color).toEqual({ value: '#FF0061' });
 			expect(errorText.value).toEqual(['ERROR', 'ERROR']);
 		});
 
@@ -154,12 +154,12 @@ describe('ParticleConfig', () => {
 
 			// Check AUTH text (green)
 			const authText = config.particles.shape.options.text[0];
-			expect(authText.particles.color).toEqual({ value: '#22c55e' });
+			expect(authText.particles.paint.color).toEqual({ value: '#22c55e' });
 			expect(authText.value).toEqual(['AUTH', 'AUTH', 'AUTH']);
 
 			// Check LOGIN text (yellow/amber)
 			const loginText = config.particles.shape.options.text[1];
-			expect(loginText.particles.color).toEqual({ value: '#fbbf24' });
+			expect(loginText.particles.paint.color).toEqual({ value: '#fbbf24' });
 			expect(loginText.value).toEqual(['LOGIN', 'LOGIN']);
 		});
 

--- a/webapp/tests/lib/utils/ccbilling-parsers/chase-parser.test.js
+++ b/webapp/tests/lib/utils/ccbilling-parsers/chase-parser.test.js
@@ -463,201 +463,203 @@ describe('ChaseParser', () => {
 	});
 });
 
-	describe('getPaymentKeywords', () => {
-		it('should return chase specific payment keywords', () => {
-			const parser = new ChaseParser();
-			const keywords = parser.getPaymentKeywords();
-			expect(keywords).toContain('payment thank you');
-			expect(keywords).toContain('online payment');
+describe('getPaymentKeywords', () => {
+	it('should return chase specific payment keywords', () => {
+		const parser = new ChaseParser();
+		const keywords = parser.getPaymentKeywords();
+		expect(keywords).toContain('payment thank you');
+		expect(keywords).toContain('online payment');
+	});
+});
+
+describe('isLikelyShopWithPointsTransaction', () => {
+	it('should identify shop with points transactions', () => {
+		const parser = new ChaseParser();
+		expect(
+			parser.isLikelyShopWithPointsTransaction(
+				'Amazon',
+				1500,
+				'01/01 AMZN.COM/BILLWA AMZN.COM/BILLWA WA $1500.00'
+			)
+		).toBe(true);
+		expect(
+			parser.isLikelyShopWithPointsTransaction(
+				'Amazon Shop with points',
+				10,
+				'01/01 Amazon Shop with points WA $10.00'
+			)
+		).toBe(true);
+		expect(parser.isLikelyShopWithPointsTransaction('Target', 10, '01/01 Target WA $10.00')).toBe(
+			false
+		);
+	});
+});
+
+describe('isFlightTransaction', () => {
+	it('should identify flight transactions', () => {
+		const parser = new ChaseParser();
+		expect(parser.isFlightTransaction('UNITED AIRLINES')).toBe(true);
+		expect(parser.isFlightTransaction('AMERICAN AIRLINES')).toBe(true);
+		expect(parser.isFlightTransaction('DELTA AIRLINES')).toBe(true);
+		expect(parser.isFlightTransaction('JETBLUE AIRWAYS')).toBe(true);
+		expect(parser.isFlightTransaction('WALMART')).toBe(false);
+	});
+});
+
+describe('extractFlightDetails', () => {
+	it('should extract flight details', () => {
+		const parser = new ChaseParser();
+		const lines = ['01/01 UNITED AIRLINES $100.00', '012345 123 U SFO JFK', '01/02 WALMART $50.00'];
+		const details = parser.extractFlightDetails(lines, 0);
+		expect(details.departure_airport).toBe('SFO');
+		expect(details.arrival_airport).toBe('JFK');
+		expect(details.airline).toBe('UNITED');
+	});
+
+	it('should extract flight details simple', () => {
+		const parser = new ChaseParser();
+		const lines = ['01/01 UNITED AIRLINES $100.00', 'SFO JFK', '01/02 WALMART $50.00'];
+		const details = parser.extractFlightDetails(lines, 0);
+		expect(details.departure_airport).toBe('SFO');
+		expect(details.arrival_airport).toBe('JFK');
+	});
+
+	it('should handle flight transactions with no details', () => {
+		const parser = new ChaseParser();
+		const lines = ['01/01 UNITED AIRLINES $100.00', 'SOME OTHER STUFF', '01/02 WALMART $50.00'];
+		const details = parser.extractFlightDetails(lines, 0);
+		expect(details.airline).toBe('UNITED');
+		expect(details.departure_airport).toBe(null);
+	});
+});
+
+describe('isLikelyForeignTransaction', () => {
+	it('should identify likely foreign transactions', () => {
+		const parser = new ChaseParser();
+		expect(parser.isLikelyForeignTransaction('SOMETHING EURO')).toBe(true);
+		expect(parser.isLikelyForeignTransaction('POUND PUB')).toBe(true);
+		expect(parser.isLikelyForeignTransaction('YEN STORE')).toBe(true);
+		expect(parser.isLikelyForeignTransaction('DSB TRAIN')).toBe(true);
+		expect(parser.isLikelyForeignTransaction('WALMART')).toBe(false);
+	});
+});
+
+describe('_parseCurrencyInfo', () => {
+	it('should parse currency info from rate line only', () => {
+		const parser = new ChaseParser();
+		const lines = ['123.45 X 0.67', 'OTHER'];
+		const info = parser._parseCurrencyInfo(lines[0], lines, 0);
+		expect(info.is_foreign_currency).toBe(true);
+		expect(info.foreign_currency_amount).toBe(123.45);
+	});
+
+	it('should parse currency info with rate on next line', () => {
+		const parser = new ChaseParser();
+		const lines = ['EURO', '123.45 X 0.67'];
+		const info = parser._parseCurrencyInfo(lines[0], lines, 0);
+		expect(info.is_foreign_currency).toBe(true);
+		expect(info.foreign_currency_amount).toBe(123.45);
+	});
+});
+
+describe('_parseAirportCodesFromLine', () => {
+	it('should parse simple airport codes', () => {
+		const parser = new ChaseParser();
+		expect(parser._parseAirportCodesFromLine('SFO JFK')).toEqual({
+			departure_airport: 'SFO',
+			arrival_airport: 'JFK'
 		});
 	});
 
-	describe('isLikelyShopWithPointsTransaction', () => {
-		it('should identify shop with points transactions', () => {
-			const parser = new ChaseParser();
-			expect(parser.isLikelyShopWithPointsTransaction('Amazon', 1500, '01/01 AMZN.COM/BILLWA AMZN.COM/BILLWA WA $1500.00')).toBe(true);
-			expect(parser.isLikelyShopWithPointsTransaction('Amazon Shop with points', 10, '01/01 Amazon Shop with points WA $10.00')).toBe(true);
-			expect(parser.isLikelyShopWithPointsTransaction('Target', 10, '01/01 Target WA $10.00')).toBe(false);
+	it('should parse detailed airport codes', () => {
+		const parser = new ChaseParser();
+		expect(parser._parseAirportCodesFromLine('123456 123 U SFO JFK')).toEqual({
+			departure_airport: 'SFO',
+			arrival_airport: 'JFK'
 		});
 	});
 
-	describe('isFlightTransaction', () => {
-		it('should identify flight transactions', () => {
-			const parser = new ChaseParser();
-			expect(parser.isFlightTransaction('UNITED AIRLINES')).toBe(true);
-			expect(parser.isFlightTransaction('AMERICAN AIRLINES')).toBe(true);
-			expect(parser.isFlightTransaction('DELTA AIRLINES')).toBe(true);
-			expect(parser.isFlightTransaction('JETBLUE AIRWAYS')).toBe(true);
-			expect(parser.isFlightTransaction('WALMART')).toBe(false);
-		});
+	it('should return null if invalid format', () => {
+		const parser = new ChaseParser();
+		expect(parser._parseAirportCodesFromLine('SOME INVALID TEXT')).toBe(null);
+	});
+});
+
+describe('parseDate', () => {
+	it('should return null for invalid date parts', () => {
+		const parser = new ChaseParser();
+		expect(parser.parseDate('99/99/2023')).toBe(null);
+		expect(parser.parseDate('00/00/2023')).toBe(null);
+	});
+});
+
+describe('updateSectionState', () => {
+	it('should exit shop with points section correctly', () => {
+		const parser = new ChaseParser();
+		let state = parser.updateSectionState('SHOP WITH POINTS ACTIVITY', false);
+		expect(state.inShopWithPointsSection).toBe(true);
+
+		state = parser.updateSectionState('SOME ITEM', state.inShopWithPointsSection);
+		expect(state.inShopWithPointsSection).toBe(true);
+
+		state = parser.updateSectionState('INTEREST CHARGES', state.inShopWithPointsSection);
+		expect(state.inShopWithPointsSection).toBe(false);
+
+		state = parser.updateSectionState('SHOP WITH POINTS ACTIVITY', false);
+		state = parser.updateSectionState('YOUR ACCOUNT MESSAGES', state.inShopWithPointsSection);
+		expect(state.inShopWithPointsSection).toBe(false);
+	});
+});
+
+describe('safeMatchExchangeRate', () => {
+	it('should return null for invalid inputs', () => {
+		const parser = new ChaseParser();
+		expect(parser.safeMatchExchangeRate('INVALID X TEXT')).toBe(null);
+		expect(parser.safeMatchExchangeRate('123.45 X TEXT')).toBe(null);
+		expect(parser.safeMatchExchangeRate('123.45 X')).toBe(null);
+	});
+});
+
+describe('parseChaseDate4Digit', () => {
+	it('should handle missing dates', () => {
+		const parser = new ChaseParser();
+		expect(parser.parseChaseDate4Digit('')).toBe(null);
 	});
 
-	describe('extractFlightDetails', () => {
-		it('should extract flight details', () => {
-			const parser = new ChaseParser();
-			const lines = [
-				'01/01 UNITED AIRLINES $100.00',
-				'012345 123 U SFO JFK',
-				'01/02 WALMART $50.00'
-			];
-			const details = parser.extractFlightDetails(lines, 0);
-			expect(details.departure_airport).toBe('SFO');
-			expect(details.arrival_airport).toBe('JFK');
-			expect(details.airline).toBe('UNITED');
-		});
-
-		it('should extract flight details simple', () => {
-			const parser = new ChaseParser();
-			const lines = [
-				'01/01 UNITED AIRLINES $100.00',
-				'SFO JFK',
-				'01/02 WALMART $50.00'
-			];
-			const details = parser.extractFlightDetails(lines, 0);
-			expect(details.departure_airport).toBe('SFO');
-			expect(details.arrival_airport).toBe('JFK');
-		});
-
-		it('should handle flight transactions with no details', () => {
-			const parser = new ChaseParser();
-			const lines = [
-				'01/01 UNITED AIRLINES $100.00',
-				'SOME OTHER STUFF',
-				'01/02 WALMART $50.00'
-			];
-			const details = parser.extractFlightDetails(lines, 0);
-			expect(details.airline).toBe('UNITED');
-			expect(details.departure_airport).toBe(null);
-		});
+	it('should handle invalid date values', () => {
+		const parser = new ChaseParser();
+		expect(parser.parseChaseDate4Digit('13/01/2023')).toBe(null);
+		expect(parser.parseChaseDate4Digit('01/32/2023')).toBe(null);
+		expect(parser.parseChaseDate4Digit('00/01/2023')).toBe(null);
+		expect(parser.parseChaseDate4Digit('01/00/2023')).toBe(null);
+		expect(parser.parseChaseDate4Digit('99/99/2023')).toBe(null);
 	});
 
-	describe('isLikelyForeignTransaction', () => {
-		it('should identify likely foreign transactions', () => {
-			const parser = new ChaseParser();
-			expect(parser.isLikelyForeignTransaction('SOMETHING EURO')).toBe(true);
-			expect(parser.isLikelyForeignTransaction('POUND PUB')).toBe(true);
-			expect(parser.isLikelyForeignTransaction('YEN STORE')).toBe(true);
-			expect(parser.isLikelyForeignTransaction('DSB TRAIN')).toBe(true);
-			expect(parser.isLikelyForeignTransaction('WALMART')).toBe(false);
-		});
+	it('should parse valid dates', () => {
+		const parser = new ChaseParser();
+		expect(parser.parseChaseDate4Digit('12/15/2023')).toBe('2023-12-15');
+		expect(parser.parseChaseDate4Digit('01/05/2024')).toBe('2024-01-05');
 	});
 
-	describe('_parseCurrencyInfo', () => {
-		it('should parse currency info from rate line only', () => {
-			const parser = new ChaseParser();
-			const lines = ['123.45 X 0.67', 'OTHER'];
-			const info = parser._parseCurrencyInfo(lines[0], lines, 0);
-			expect(info.is_foreign_currency).toBe(true);
-			expect(info.foreign_currency_amount).toBe(123.45);
-		});
+	it('should handle badly formatted inputs', () => {
+		const parser = new ChaseParser();
+		expect(parser.parseChaseDate4Digit('NOT A DATE')).toBe(null);
+	});
+});
 
-		it('should parse currency info with rate on next line', () => {
-			const parser = new ChaseParser();
-			const lines = ['EURO', '123.45 X 0.67'];
-			const info = parser._parseCurrencyInfo(lines[0], lines, 0);
-			expect(info.is_foreign_currency).toBe(true);
-			expect(info.foreign_currency_amount).toBe(123.45);
-		});
+describe('extractCharges - detailed coverage', () => {
+	it('should skip likely shop with points transactions', () => {
+		const parser = new ChaseParser();
+		// Mock so that updateSectionState doesn't filter it out, but isLikelyShopWithPointsTransaction does
+		const text = '01/01 AMZN.COM/BILLWA AMZN.COM/BILLWA WA 1500.00\n';
+		const charges = parser.extractCharges(text);
+		expect(charges.length).toBe(0);
 	});
 
-	describe('_parseAirportCodesFromLine', () => {
-		it('should parse simple airport codes', () => {
-			const parser = new ChaseParser();
-			expect(parser._parseAirportCodesFromLine('SFO JFK')).toEqual({
-				departure_airport: 'SFO',
-				arrival_airport: 'JFK'
-			});
-		});
-
-		it('should parse detailed airport codes', () => {
-			const parser = new ChaseParser();
-			expect(parser._parseAirportCodesFromLine('123456 123 U SFO JFK')).toEqual({
-				departure_airport: 'SFO',
-				arrival_airport: 'JFK'
-			});
-		});
-
-		it('should return null if invalid format', () => {
-			const parser = new ChaseParser();
-			expect(parser._parseAirportCodesFromLine('SOME INVALID TEXT')).toBe(null);
-		});
+	it('should continue if inShopWithPointsSection is already true', () => {
+		const parser = new ChaseParser();
+		const text = 'SHOP WITH POINTS ACTIVITY\n01/01 SOME MERCHANT 10.00\n';
+		const charges = parser.extractCharges(text);
+		expect(charges.length).toBe(0);
 	});
-
-	describe('parseDate', () => {
-		it('should return null for invalid date parts', () => {
-			const parser = new ChaseParser();
-			expect(parser.parseDate('99/99/2023')).toBe(null);
-			expect(parser.parseDate('00/00/2023')).toBe(null);
-		});
-	});
-
-	describe('updateSectionState', () => {
-		it('should exit shop with points section correctly', () => {
-			const parser = new ChaseParser();
-			let state = parser.updateSectionState('SHOP WITH POINTS ACTIVITY', false);
-			expect(state.inShopWithPointsSection).toBe(true);
-
-			state = parser.updateSectionState('SOME ITEM', state.inShopWithPointsSection);
-			expect(state.inShopWithPointsSection).toBe(true);
-
-			state = parser.updateSectionState('INTEREST CHARGES', state.inShopWithPointsSection);
-			expect(state.inShopWithPointsSection).toBe(false);
-
-			state = parser.updateSectionState('SHOP WITH POINTS ACTIVITY', false);
-			state = parser.updateSectionState('YOUR ACCOUNT MESSAGES', state.inShopWithPointsSection);
-			expect(state.inShopWithPointsSection).toBe(false);
-		});
-	});
-
-	describe('safeMatchExchangeRate', () => {
-		it('should return null for invalid inputs', () => {
-			const parser = new ChaseParser();
-			expect(parser.safeMatchExchangeRate('INVALID X TEXT')).toBe(null);
-			expect(parser.safeMatchExchangeRate('123.45 X TEXT')).toBe(null);
-			expect(parser.safeMatchExchangeRate('123.45 X')).toBe(null);
-		});
-	});
-
-	describe('parseChaseDate4Digit', () => {
-		it('should handle missing dates', () => {
-			const parser = new ChaseParser();
-			expect(parser.parseChaseDate4Digit('')).toBe(null);
-		});
-
-		it('should handle invalid date values', () => {
-			const parser = new ChaseParser();
-			expect(parser.parseChaseDate4Digit('13/01/2023')).toBe(null);
-			expect(parser.parseChaseDate4Digit('01/32/2023')).toBe(null);
-			expect(parser.parseChaseDate4Digit('00/01/2023')).toBe(null);
-			expect(parser.parseChaseDate4Digit('01/00/2023')).toBe(null);
-			expect(parser.parseChaseDate4Digit('99/99/2023')).toBe(null);
-		});
-
-		it('should parse valid dates', () => {
-			const parser = new ChaseParser();
-			expect(parser.parseChaseDate4Digit('12/15/2023')).toBe('2023-12-15');
-			expect(parser.parseChaseDate4Digit('01/05/2024')).toBe('2024-01-05');
-		});
-
-		it('should handle badly formatted inputs', () => {
-			const parser = new ChaseParser();
-			expect(parser.parseChaseDate4Digit('NOT A DATE')).toBe(null);
-		});
-	});
-
-	describe('extractCharges - detailed coverage', () => {
-		it('should skip likely shop with points transactions', () => {
-			const parser = new ChaseParser();
-			// Mock so that updateSectionState doesn't filter it out, but isLikelyShopWithPointsTransaction does
-			const text = "01/01 AMZN.COM/BILLWA AMZN.COM/BILLWA WA 1500.00\n";
-			const charges = parser.extractCharges(text);
-			expect(charges.length).toBe(0);
-		});
-
-		it('should continue if inShopWithPointsSection is already true', () => {
-			const parser = new ChaseParser();
-			const text = "SHOP WITH POINTS ACTIVITY\n01/01 SOME MERCHANT 10.00\n";
-			const charges = parser.extractCharges(text);
-			expect(charges.length).toBe(0);
-		});
-	});
+});

--- a/webapp/tests/lib/utils/date-utils.test.js
+++ b/webapp/tests/lib/utils/date-utils.test.js
@@ -4,7 +4,8 @@ import {
 	formatShortDate,
 	formatMediumDate,
 	formatMonthYear,
-	formatRelativeTime, formatTime,
+	formatRelativeTime,
+	formatTime,
 	parseISODateParts,
 	isToday,
 	isYesterday
@@ -67,8 +68,8 @@ describe('date-utils', () => {
 	});
 });
 
-	describe('formatTime', () => {
-		it('should handle pure date inputs YYYY-MM-DD gracefully', () => {
-			expect(formatTime('2023-01-15')).toBe('');
-		});
+describe('formatTime', () => {
+	it('should handle pure date inputs YYYY-MM-DD gracefully', () => {
+		expect(formatTime('2023-01-15')).toBe('');
 	});
+});

--- a/webapp/tests/routes/index.svelte.test.js
+++ b/webapp/tests/routes/index.svelte.test.js
@@ -8,7 +8,6 @@ vi.mock('@tsparticles/engine');
 describe.skip('App', () => {
 	vi.stubGlobal('ResizeObserver', ResizeObserver);
 
-
 	// Needed per https://github.com/testing-library/svelte-testing-library/issues/284
 	Element.prototype.animate = () => ({ cancel: vi.fn(), finished: Promise.resolve() });
 


### PR DESCRIPTION
Upgrades `tsparticles` to v4 while preserving the visual behavior of the financial particles. The `links` configuration is now explicitly defined for each text shape configuration using the v4 syntax so the connecting lines remain white. Also added relevant tests to confirm the lines are configured correctly.

---
*PR created automatically by Jules for task [10713952199221287267](https://jules.google.com/task/10713952199221287267) started by @nickbrett1*