### PR TITLE
Fix npm install ERESOLVE by aligning @tsparticles/slim version

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -15,7 +15,7 @@
 				"@tsparticles/engine": "^4.0.4",
 				"@tsparticles/interaction-external-trail": "^4.0.4",
 				"@tsparticles/shape-text": "^4.0.4",
-				"@tsparticles/slim": "^4.0.2",
+				"@tsparticles/slim": "^4.0.4",
 				"apexcharts": "^5.12.0",
 				"arctic": "^3.7.0",
 				"cookie": "^1.1.1",
@@ -316,27 +316,27 @@
 			}
 		},
 		"node_modules/@cloudflare/vite-plugin": {
-			"version": "1.37.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.37.1.tgz",
-			"integrity": "sha512-FldhsmkXyLsX3yI+p0aJDo/kGyY69pDdynz2JjcuH3eCiQ+G9XaY3CrN+UYEfCbWv8CiR2wL95lNg0fT/HfwWA==",
+			"version": "1.37.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.37.2.tgz",
+			"integrity": "sha512-+QSQVdRcaRp63R3PqPHuIxqZUJnp1wJI2C+Un3DuwYAy2rjiHXKHwAvPWeUWIB8u04sydPFEuOwa0RaZA/hsJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cloudflare/unenv-preset": "2.16.1",
-				"miniflare": "4.20260515.0",
+				"miniflare": "4.20260518.0",
 				"unenv": "2.0.0-rc.24",
-				"wrangler": "4.92.0",
+				"wrangler": "4.93.0",
 				"ws": "8.18.0"
 			},
 			"peerDependencies": {
 				"vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
-				"wrangler": "^4.92.0"
+				"wrangler": "^4.93.0"
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260515.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260515.1.tgz",
-			"integrity": "sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==",
+			"version": "1.20260518.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260518.1.tgz",
+			"integrity": "sha512-IhZEf5kDd0CLRtFxGS9AUqfM5SY3EFScqqCY1VF9twNMdYpJDYrDZDJAkQitHF8sF/sPVVHYR4Aifpdq6tzmaA==",
 			"cpu": [
 				"x64"
 			],
@@ -351,9 +351,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260515.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260515.1.tgz",
-			"integrity": "sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ==",
+			"version": "1.20260518.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260518.1.tgz",
+			"integrity": "sha512-uqlNP1psd8SWfN1Lg5p8ePv8/piOOXt+ycvb8+NQopXECGeh9+PQ/yr/IQjpurxBhYpvSaMC+vEeihejahjkJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -368,9 +368,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260515.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260515.1.tgz",
-			"integrity": "sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==",
+			"version": "1.20260518.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260518.1.tgz",
+			"integrity": "sha512-D9p8Hl0lIQ46nYs4fQZp5F+9hhvgOcQJTF1SMQWpAxQSS5f8oX+vL5YdCrETUYnyoaoyEQETtkRrWYKJkPTFeg==",
 			"cpu": [
 				"x64"
 			],
@@ -385,9 +385,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260515.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260515.1.tgz",
-			"integrity": "sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA==",
+			"version": "1.20260518.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260518.1.tgz",
+			"integrity": "sha512-+vNRkuOp9E/uRKHgQXVDUBPF5cwtTeXK6+ucLK50QUFzMYycqVl8kTFN2b//BX2H5BI4bjMRhXoBpe/zAlGRWQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -402,9 +402,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260515.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260515.1.tgz",
-			"integrity": "sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==",
+			"version": "1.20260518.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260518.1.tgz",
+			"integrity": "sha512-tnqofUq+ZvKliQHhboygbH7iy/Zm/MaCCotIlrqVj5a988+tPtndxyLM0r4vaAIC10iy/2LWCkwnE67VFTFiUA==",
 			"cpu": [
 				"x64"
 			],
@@ -419,9 +419,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260518.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260518.1.tgz",
-			"integrity": "sha512-xXzGrbRi8RHRBNQFgXYkzrB4DgF0RXvmp8E1vCxoBmINpeitM/ZjVDd1CNC+N3uXjgcNjacoz4OgTa0rxgig1A==",
+			"version": "4.20260519.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260519.1.tgz",
+			"integrity": "sha512-BMWAwg4RyyZn3zcdoXbqpfogm2DGfNb83DXNCM1oFUMhYtEX8I+B+oxf67YPKvSiAEbzd7nHzW2mLv3eBH8Etw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0"
 		},
@@ -1439,6 +1439,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1456,6 +1459,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1473,6 +1479,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1490,6 +1499,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1507,6 +1519,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1524,6 +1539,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1541,6 +1559,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1558,6 +1579,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1575,6 +1599,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1598,6 +1625,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1621,6 +1651,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1644,6 +1677,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1667,6 +1703,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1690,6 +1729,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1713,6 +1755,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1736,6 +1781,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -2063,6 +2111,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2082,6 +2133,9 @@
 			"integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2103,6 +2157,9 @@
 			"cpu": [
 				"riscv64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2123,6 +2180,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2142,6 +2202,9 @@
 			"integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2439,6 +2502,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2456,6 +2522,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2473,6 +2542,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2490,6 +2562,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2507,6 +2582,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2524,6 +2602,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3043,6 +3124,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3060,6 +3144,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3077,6 +3164,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3094,6 +3184,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3372,19 +3465,10 @@
 				"@tsparticles/updater-size": "4.0.4"
 			}
 		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/plugin-blend": {
+		"node_modules/@tsparticles/canvas-utils": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-blend/-/plugin-blend-4.0.4.tgz",
-			"integrity": "sha512-XY0AvvESoXQS6pVJD7kez8oORzfbI4hzlqCMTPwCsiWFP3f7uUnQyz+3R1KLC33jqZQhpzalFf9G0wTj2Egr3Q==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/plugin-hex-color": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-4.0.4.tgz",
-			"integrity": "sha512-x9l+4tqQkBBbEQN2msasC+Hqe/ojNWz1JEIp0dK7NYGMgaY9ooug+IvoQazNut3ke2R9yFUoU8lj3OEZ6GE+Wg==",
+			"resolved": "https://registry.npmjs.org/@tsparticles/canvas-utils/-/canvas-utils-4.0.4.tgz",
+			"integrity": "sha512-ivLF6bWAFfJj8lyDvWTEbdAO5yPqrlkr0vFI3OorsUsMMru77ZrU5Vlr1Uw+yYQQ5RZNULIaAo+JQ996jylBdA==",
 			"funding": [
 				{
 					"type": "github",
@@ -3399,106 +3483,6 @@
 					"url": "https://www.buymeacoffee.com/matteobruni"
 				}
 			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/plugin-hsl-color": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-4.0.4.tgz",
-			"integrity": "sha512-3Rh5malxB+dtdkGmqh470OFfelL//Qr3HKj8jukkEnpiTfDjpgNEscISDymxLdb8H06vQzFP8s1eo4ZAsPGLgQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/matteobruni"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/tsparticles"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://www.buymeacoffee.com/matteobruni"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/plugin-move": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-move/-/plugin-move-4.0.4.tgz",
-			"integrity": "sha512-JOP+0caRlF3Uf6+QvfncOcgHRf2S+d6EJtCktK/7aWobKWlEbXkRAkAHOi91VKVPanDUhxe50prduzTG5OJddw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/plugin-rgb-color": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-4.0.4.tgz",
-			"integrity": "sha512-Dd8nw4e5Hs8HOj8IjuM3hqyeZY6l300qifOu6ZpV/viE5hKFtB/EfkQOMjG2bmsO/MH1LuNeLakTk3wxpGbywg==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/matteobruni"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/tsparticles"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://www.buymeacoffee.com/matteobruni"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/shape-circle": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-4.0.4.tgz",
-			"integrity": "sha512-upauaL03H+llIRu6vgpUpxHRpOFalF9nYY9u2LYUBSka4+z0Qp5iqx1/IuPyqwZ5mZBbAntoC05k6PB7LGmaIw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/updater-opacity": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-4.0.4.tgz",
-			"integrity": "sha512-pbAAjBlWOz/0UBk0eZUHTvWvyAabZd6Re5lDefmpTHYyCdb7QgWxxpgqZ5u/bEVDZO8ju1LH+7Rwe27BLNsSNQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/updater-out-modes": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-4.0.4.tgz",
-			"integrity": "sha512-nraXjh7ww2BQFp0eK3oDpj4M8+el8CIQNUGVxxfghzERquWMUC/VROwYf5w7cljOEldDdk/NyXQrsOEMxA0fAQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/updater-paint": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-paint/-/updater-paint-4.0.4.tgz",
-			"integrity": "sha512-aoEHubEgOHRdk+EhaSC51Rm+D0+/5rmkrRUXcdM3snaejXyGtGcUZiZlczZeGHd5gxW9Nxn0Y0SQcWtHLai8VA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/basic/node_modules/@tsparticles/updater-size": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-4.0.4.tgz",
-			"integrity": "sha512-0ojFmKSnC8mENh+9O4QTzuYErnB7WKYogEVc7Pa4LYzV9fxHMAP+aBHRBUAtRWxfm7U2WOqteOjZ8FReJrhxNw==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@tsparticles/engine": "4.0.4"
@@ -3525,6 +3509,142 @@
 			"hasInstallScript": true,
 			"license": "MIT"
 		},
+		"node_modules/@tsparticles/interaction-external-attract": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-4.0.4.tgz",
+			"integrity": "sha512-QSTvaPdaRQd6OSUNJ33JoOz3iIOQMFdmnaqR4TDo5T3p+0dqkGuDWxj08ckjNIfiqbZZKpO3hLcbRtkYsKWJew==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-bounce": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-4.0.4.tgz",
+			"integrity": "sha512-MiqAI67mZpQzSWkwhBGkdb2nGP2QsuEBBgSX46ouU7M0/Ew1CDEyQVK9eKn7tAWldUoDLF4M8c02eF/ovAfByg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-bubble": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-4.0.4.tgz",
+			"integrity": "sha512-VqL17FA3CYoNEOZ1zbvbD1sZsSIXtk2bEPfcUc2DTrdJmmYBQxfUwqb1WMSYmFqI/M3fRJbY4hzltwJig/1i4A==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-connect": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-4.0.4.tgz",
+			"integrity": "sha512-BlMYsk/+70MviAmDq0Eabbke6e5X9XfLn83lq4QzaRNc0B+2WEORQp/TWzdNKupssgTvxoqmTtTtccWC/QqoTw==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/canvas-utils": "4.0.4"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-destroy": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-destroy/-/interaction-external-destroy-4.0.4.tgz",
+			"integrity": "sha512-LIio2HVWRpcbvHPUP+oYF3kaeE+KJYLxLgJVMENuvUCxdxTk5e1vpWtaKjes8Wu8X81r0x0x1G5rkkXrn11oAg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-drag": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-drag/-/interaction-external-drag-4.0.4.tgz",
+			"integrity": "sha512-CG7XE1jWKOM4+VzhLSbcfCqhaMMdDj1bauECWffme3vOekCU38mdGwNozcr7+WyCTfKKMadSqeLRcmpiYIJzLA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-grab": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-4.0.4.tgz",
+			"integrity": "sha512-NTlei1BRaxWEreXYSevSEw3B0gwPUJQshKe9fY6XT8MkNrrmY0dybUxpOj1CfmUk54UqiUQ733n+MIwAueX3Og==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/canvas-utils": "4.0.4"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-parallax": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-parallax/-/interaction-external-parallax-4.0.4.tgz",
+			"integrity": "sha512-33W9nvbMkgDDrez0TU2UFiBCwRsjZdmHbGIZy08O2cuk6EqR2AvGEguzE+UNXl42tUzWyO+fWlPs/K+Q2ngn2A==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-pause": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-4.0.4.tgz",
+			"integrity": "sha512-EVY+84Q2K4fzs+ddKZ3vKelZkrGhNzjyPkSMgg+xNkpaYQmA0w3kPH5oKgv4+tHXD/FN0ADt0SLGL3KisSN5CA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-push": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-4.0.4.tgz",
+			"integrity": "sha512-MvuINaQViTOtnuAHcfVoOC+63tvW/qnXzETGYUjeGtJo/19mHhfLruOrE6t/WELULXSAplfx7aGpVbsy/4MY1w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-remove": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-4.0.4.tgz",
+			"integrity": "sha512-3eN6Fb17alU6q9f4JFA/ysOQCP/echTElET+siBu3q86sB6Zg8AXZiOlDa5sa1fAi1NaN7SUioKoRa3u8alNsA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-repulse": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-4.0.4.tgz",
+			"integrity": "sha512-pA/t84Ngq/HNOhHLAQpZx1YB5Jmd9JEdu4XloPw6WSgF2zlTTue+fQ6kOyMLURstnE2Xrw6l2Hh8SUJsn8UfZg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-slow": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-4.0.4.tgz",
+			"integrity": "sha512-QKRmhxUQCeK/NUI5AHKc4FTAwkZp1EdCNIsOub6PdLyU2xSXbMtCQR8unt+njUGQtS2DHZ1MCuG6yU3rEwNTxA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
 		"node_modules/@tsparticles/interaction-external-trail": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-trail/-/interaction-external-trail-4.0.4.tgz",
@@ -3535,31 +3655,67 @@
 				"@tsparticles/plugin-interactivity": "4.0.4"
 			}
 		},
-		"node_modules/@tsparticles/plugin-interactivity": {
+		"node_modules/@tsparticles/interaction-particles-attract": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-interactivity/-/plugin-interactivity-4.0.4.tgz",
-			"integrity": "sha512-e3NdfGJbE5aAW1ukd+fiPesmHtkmbGB2AfAVDXiAxRdAy/NqaqZqAHCPCPxAqYNCx+j9JkqOLxmWXEelVFXppQ==",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-4.0.4.tgz",
+			"integrity": "sha512-V2kgBzXawt9LQvNBfmrnl0lossfs0gcSllmuVPjh1EgeFxdRtcwMKB0G73zGXt76PnEJTwCJXmdj44QhD6KEsg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
 			}
 		},
-		"node_modules/@tsparticles/shape-text": {
+		"node_modules/@tsparticles/interaction-particles-collisions": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-4.0.4.tgz",
-			"integrity": "sha512-fwVWiQkwk/adLv2UuNst/+iyU/zYww3UT7r+7sMB0OqPgqMvm4paBHgNCEOZZYNKEFzJCKRRTOW+au/piwAKEA==",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-4.0.4.tgz",
+			"integrity": "sha512-uz1n7XO7+N4WjnACuzVDlUK2A4FBbMqym7UG2dCg3er+axEfwa3gbhDk+wTSUM11V6FxR9HVCPLqyAh54pn2dQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/interaction-particles-links": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-4.0.4.tgz",
+			"integrity": "sha512-mjN1DhACIHvOQNv0YkJMLytlKdq1cOfy+MkHeGIYLBWVUJEF26ol+mQi/9C11ffcPmug1eVlcl0CQdGcYD7rpQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@tsparticles/canvas-utils": "4.0.4"
 			},
 			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/plugin-absorbers": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-4.0.4.tgz",
+			"integrity": "sha512-LOJITOePmKi9V6rTDIVJmTcH9j9dS4OyVFmxt5tTdl7iQpVEMMwr9L8HVzNMcgcA+Iy6J1b/OW76UtNMhgBFww==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			},
+			"peerDependenciesMeta": {
+				"@tsparticles/plugin-interactivity": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tsparticles/plugin-blend": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-blend/-/plugin-blend-4.0.4.tgz",
+			"integrity": "sha512-XY0AvvESoXQS6pVJD7kez8oORzfbI4hzlqCMTPwCsiWFP3f7uUnQyz+3R1KLC33jqZQhpzalFf9G0wTj2Egr3Q==",
+			"license": "MIT",
+			"peerDependencies": {
 				"@tsparticles/engine": "4.0.4"
 			}
 		},
-		"node_modules/@tsparticles/shape-text/node_modules/@tsparticles/canvas-utils": {
+		"node_modules/@tsparticles/plugin-easing-quad": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/canvas-utils/-/canvas-utils-4.0.4.tgz",
-			"integrity": "sha512-ivLF6bWAFfJj8lyDvWTEbdAO5yPqrlkr0vFI3OorsUsMMru77ZrU5Vlr1Uw+yYQQ5RZNULIaAo+JQ996jylBdA==",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-4.0.4.tgz",
+			"integrity": "sha512-OxG8ec3VqbnGRigQF0Bd/V523q7WfwFut8xhYKHUJsbRqX9a4RrqLCU728XXeOSyeg61sSvlUqIsVSLumrmYIQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -3575,6 +3731,234 @@
 				}
 			],
 			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/plugin-emitters": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-4.0.4.tgz",
+			"integrity": "sha512-ep4ElX2vrzreaWSqhSLzw+GYb/wh+743Al2Gdf+wR7ctqSrgDQYyKU27+nPRnUR+IF8CQ1tUBMsTl0oPPvUnvg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-interactivity": "4.0.4"
+			},
+			"peerDependenciesMeta": {
+				"@tsparticles/plugin-interactivity": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tsparticles/plugin-emitters-shape-circle": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-4.0.4.tgz",
+			"integrity": "sha512-wp6/RUOoNWU3AjNEXrX8RkTLCceHoRDQE2+NgLWcLviftEmTKQf3TX4TkXmp09NSSVtyIiyA4UUgN4P6ytwDGw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/matteobruni"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/tsparticles"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://www.buymeacoffee.com/matteobruni"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-emitters": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/plugin-emitters-shape-square": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-4.0.4.tgz",
+			"integrity": "sha512-SbvJj/kzMYn0cGeo/v4QQu6gOfrHd99xepIhKO79N99lCZAbqOPC+dqcBlPFw8PfRic+xmMJCwHW7IYlDuhAUw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/matteobruni"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/tsparticles"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://www.buymeacoffee.com/matteobruni"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4",
+				"@tsparticles/plugin-emitters": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/plugin-hex-color": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-4.0.4.tgz",
+			"integrity": "sha512-x9l+4tqQkBBbEQN2msasC+Hqe/ojNWz1JEIp0dK7NYGMgaY9ooug+IvoQazNut3ke2R9yFUoU8lj3OEZ6GE+Wg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/matteobruni"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/tsparticles"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://www.buymeacoffee.com/matteobruni"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/plugin-hsl-color": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-4.0.4.tgz",
+			"integrity": "sha512-3Rh5malxB+dtdkGmqh470OFfelL//Qr3HKj8jukkEnpiTfDjpgNEscISDymxLdb8H06vQzFP8s1eo4ZAsPGLgQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/matteobruni"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/tsparticles"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://www.buymeacoffee.com/matteobruni"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/plugin-interactivity": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-interactivity/-/plugin-interactivity-4.0.4.tgz",
+			"integrity": "sha512-e3NdfGJbE5aAW1ukd+fiPesmHtkmbGB2AfAVDXiAxRdAy/NqaqZqAHCPCPxAqYNCx+j9JkqOLxmWXEelVFXppQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/plugin-move": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-move/-/plugin-move-4.0.4.tgz",
+			"integrity": "sha512-JOP+0caRlF3Uf6+QvfncOcgHRf2S+d6EJtCktK/7aWobKWlEbXkRAkAHOi91VKVPanDUhxe50prduzTG5OJddw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/plugin-rgb-color": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-4.0.4.tgz",
+			"integrity": "sha512-Dd8nw4e5Hs8HOj8IjuM3hqyeZY6l300qifOu6ZpV/viE5hKFtB/EfkQOMjG2bmsO/MH1LuNeLakTk3wxpGbywg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/matteobruni"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/tsparticles"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://www.buymeacoffee.com/matteobruni"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/shape-circle": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-4.0.4.tgz",
+			"integrity": "sha512-upauaL03H+llIRu6vgpUpxHRpOFalF9nYY9u2LYUBSka4+z0Qp5iqx1/IuPyqwZ5mZBbAntoC05k6PB7LGmaIw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/shape-emoji": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-4.0.4.tgz",
+			"integrity": "sha512-lq4pgf5u8qXKsuzpZxOvz6s1zbnhItY1lfprS0x30y26I5QfzThcEVayXCf/Jj33KIMe79uyPLtY1H3vVVrOIA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/canvas-utils": "4.0.4"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/shape-image": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-4.0.4.tgz",
+			"integrity": "sha512-KSWHMvv04ffEapmFf8HjF1nwvCm8Q7OPEAKZoTMThvNN9RMKneb2gQkxjU1HQWViQIJzgJ2jPBsNwYXRpGewyg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/shape-line": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-4.0.4.tgz",
+			"integrity": "sha512-jzixuwuIPKeJA7BObAFmcHyYy3/Vfp3qDkDqtlpLHW7vmifZmdZ0xYMoIumLfvPUvUUMvXQwk3M53CmrR1XPng==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/shape-polygon": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-4.0.4.tgz",
+			"integrity": "sha512-+wV3lgmSzzQAEbEnP5NKzIpWJcYuL7JsI2XyUW1zl7wuWT1SmjgSu1zRPJG7/v2J3BMKnRp+yFzNHQBOrRm5/g==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/shape-square": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-4.0.4.tgz",
+			"integrity": "sha512-3lemqnG3iuHOmRQT5gW5IRZmZ80bXt6oGqqm9wpnWiHeAbGP60VV1D5fnO66QiEFj7oOg55iOT9J7gYeo9QMwQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/shape-star": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-4.0.4.tgz",
+			"integrity": "sha512-ow3HP1D5q1WNyqp1y+95qUzLniUIbMxAUNxgz5m9Q+Hvws/dV1XN8OLbyfCSg8q6K4fbQuCTQv/ReUitBm/oBg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/shape-text": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-4.0.4.tgz",
+			"integrity": "sha512-fwVWiQkwk/adLv2UuNst/+iyU/zYww3UT7r+7sMB0OqPgqMvm4paBHgNCEOZZYNKEFzJCKRRTOW+au/piwAKEA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/canvas-utils": "4.0.4"
+			},
 			"peerDependencies": {
 				"@tsparticles/engine": "4.0.4"
 			}
@@ -3629,269 +4013,16 @@
 				"@tsparticles/updater-rotate": "4.0.4"
 			}
 		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/canvas-utils": {
+		"node_modules/@tsparticles/updater-destroy": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/canvas-utils/-/canvas-utils-4.0.4.tgz",
-			"integrity": "sha512-ivLF6bWAFfJj8lyDvWTEbdAO5yPqrlkr0vFI3OorsUsMMru77ZrU5Vlr1Uw+yYQQ5RZNULIaAo+JQ996jylBdA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/matteobruni"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/tsparticles"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://www.buymeacoffee.com/matteobruni"
-				}
-			],
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-4.0.4.tgz",
+			"integrity": "sha512-Wbw8avoK3YNP7waGYzTTblYsdccwlL+NpGyAl9ML+/went65qAqFpCE8h7N1pgfrhCArwYHf2FPmtXipSUOizA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@tsparticles/engine": "4.0.4"
 			}
 		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-attract": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-4.0.4.tgz",
-			"integrity": "sha512-QSTvaPdaRQd6OSUNJ33JoOz3iIOQMFdmnaqR4TDo5T3p+0dqkGuDWxj08ckjNIfiqbZZKpO3hLcbRtkYsKWJew==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-bounce": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-4.0.4.tgz",
-			"integrity": "sha512-MiqAI67mZpQzSWkwhBGkdb2nGP2QsuEBBgSX46ouU7M0/Ew1CDEyQVK9eKn7tAWldUoDLF4M8c02eF/ovAfByg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-bubble": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-4.0.4.tgz",
-			"integrity": "sha512-VqL17FA3CYoNEOZ1zbvbD1sZsSIXtk2bEPfcUc2DTrdJmmYBQxfUwqb1WMSYmFqI/M3fRJbY4hzltwJig/1i4A==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-connect": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-4.0.4.tgz",
-			"integrity": "sha512-BlMYsk/+70MviAmDq0Eabbke6e5X9XfLn83lq4QzaRNc0B+2WEORQp/TWzdNKupssgTvxoqmTtTtccWC/QqoTw==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.4"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-destroy": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-destroy/-/interaction-external-destroy-4.0.4.tgz",
-			"integrity": "sha512-LIio2HVWRpcbvHPUP+oYF3kaeE+KJYLxLgJVMENuvUCxdxTk5e1vpWtaKjes8Wu8X81r0x0x1G5rkkXrn11oAg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-grab": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-4.0.4.tgz",
-			"integrity": "sha512-NTlei1BRaxWEreXYSevSEw3B0gwPUJQshKe9fY6XT8MkNrrmY0dybUxpOj1CfmUk54UqiUQ733n+MIwAueX3Og==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.4"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-parallax": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-parallax/-/interaction-external-parallax-4.0.4.tgz",
-			"integrity": "sha512-33W9nvbMkgDDrez0TU2UFiBCwRsjZdmHbGIZy08O2cuk6EqR2AvGEguzE+UNXl42tUzWyO+fWlPs/K+Q2ngn2A==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-pause": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-4.0.4.tgz",
-			"integrity": "sha512-EVY+84Q2K4fzs+ddKZ3vKelZkrGhNzjyPkSMgg+xNkpaYQmA0w3kPH5oKgv4+tHXD/FN0ADt0SLGL3KisSN5CA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-push": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-4.0.4.tgz",
-			"integrity": "sha512-MvuINaQViTOtnuAHcfVoOC+63tvW/qnXzETGYUjeGtJo/19mHhfLruOrE6t/WELULXSAplfx7aGpVbsy/4MY1w==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-remove": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-4.0.4.tgz",
-			"integrity": "sha512-3eN6Fb17alU6q9f4JFA/ysOQCP/echTElET+siBu3q86sB6Zg8AXZiOlDa5sa1fAi1NaN7SUioKoRa3u8alNsA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-repulse": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-4.0.4.tgz",
-			"integrity": "sha512-pA/t84Ngq/HNOhHLAQpZx1YB5Jmd9JEdu4XloPw6WSgF2zlTTue+fQ6kOyMLURstnE2Xrw6l2Hh8SUJsn8UfZg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-slow": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-4.0.4.tgz",
-			"integrity": "sha512-QKRmhxUQCeK/NUI5AHKc4FTAwkZp1EdCNIsOub6PdLyU2xSXbMtCQR8unt+njUGQtS2DHZ1MCuG6yU3rEwNTxA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-particles-attract": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-4.0.4.tgz",
-			"integrity": "sha512-V2kgBzXawt9LQvNBfmrnl0lossfs0gcSllmuVPjh1EgeFxdRtcwMKB0G73zGXt76PnEJTwCJXmdj44QhD6KEsg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-particles-collisions": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-4.0.4.tgz",
-			"integrity": "sha512-uz1n7XO7+N4WjnACuzVDlUK2A4FBbMqym7UG2dCg3er+axEfwa3gbhDk+wTSUM11V6FxR9HVCPLqyAh54pn2dQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-particles-links": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-4.0.4.tgz",
-			"integrity": "sha512-mjN1DhACIHvOQNv0YkJMLytlKdq1cOfy+MkHeGIYLBWVUJEF26ol+mQi/9C11ffcPmug1eVlcl0CQdGcYD7rpQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.4"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/plugin-easing-quad": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-4.0.4.tgz",
-			"integrity": "sha512-OxG8ec3VqbnGRigQF0Bd/V523q7WfwFut8xhYKHUJsbRqX9a4RrqLCU728XXeOSyeg61sSvlUqIsVSLumrmYIQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/matteobruni"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/tsparticles"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://www.buymeacoffee.com/matteobruni"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/shape-emoji": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-4.0.4.tgz",
-			"integrity": "sha512-lq4pgf5u8qXKsuzpZxOvz6s1zbnhItY1lfprS0x30y26I5QfzThcEVayXCf/Jj33KIMe79uyPLtY1H3vVVrOIA==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.4"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/shape-image": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-4.0.4.tgz",
-			"integrity": "sha512-KSWHMvv04ffEapmFf8HjF1nwvCm8Q7OPEAKZoTMThvNN9RMKneb2gQkxjU1HQWViQIJzgJ2jPBsNwYXRpGewyg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/shape-line": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-4.0.4.tgz",
-			"integrity": "sha512-jzixuwuIPKeJA7BObAFmcHyYy3/Vfp3qDkDqtlpLHW7vmifZmdZ0xYMoIumLfvPUvUUMvXQwk3M53CmrR1XPng==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/shape-polygon": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-4.0.4.tgz",
-			"integrity": "sha512-+wV3lgmSzzQAEbEnP5NKzIpWJcYuL7JsI2XyUW1zl7wuWT1SmjgSu1zRPJG7/v2J3BMKnRp+yFzNHQBOrRm5/g==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/shape-square": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-4.0.4.tgz",
-			"integrity": "sha512-3lemqnG3iuHOmRQT5gW5IRZmZ80bXt6oGqqm9wpnWiHeAbGP60VV1D5fnO66QiEFj7oOg55iOT9J7gYeo9QMwQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/shape-star": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-4.0.4.tgz",
-			"integrity": "sha512-ow3HP1D5q1WNyqp1y+95qUzLniUIbMxAUNxgz5m9Q+Hvws/dV1XN8OLbyfCSg8q6K4fbQuCTQv/ReUitBm/oBg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/updater-life": {
+		"node_modules/@tsparticles/updater-life": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-4.0.4.tgz",
 			"integrity": "sha512-aDDjOHq/B6oQ9az+Q89NLoaMCeqgRyo+0a6eFooa+UycJyzZTNI7VwUecW/1/LpEFdiVD9qKjzbf8VJLMlVMDQ==",
@@ -3900,7 +4031,25 @@
 				"@tsparticles/engine": "4.0.4"
 			}
 		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/updater-paint": {
+		"node_modules/@tsparticles/updater-opacity": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-4.0.4.tgz",
+			"integrity": "sha512-pbAAjBlWOz/0UBk0eZUHTvWvyAabZd6Re5lDefmpTHYyCdb7QgWxxpgqZ5u/bEVDZO8ju1LH+7Rwe27BLNsSNQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/updater-out-modes": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-4.0.4.tgz",
+			"integrity": "sha512-nraXjh7ww2BQFp0eK3oDpj4M8+el8CIQNUGVxxfghzERquWMUC/VROwYf5w7cljOEldDdk/NyXQrsOEMxA0fAQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/updater-paint": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@tsparticles/updater-paint/-/updater-paint-4.0.4.tgz",
 			"integrity": "sha512-aoEHubEgOHRdk+EhaSC51Rm+D0+/5rmkrRUXcdM3snaejXyGtGcUZiZlczZeGHd5gxW9Nxn0Y0SQcWtHLai8VA==",
@@ -3909,10 +4058,55 @@
 				"@tsparticles/engine": "4.0.4"
 			}
 		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/updater-rotate": {
+		"node_modules/@tsparticles/updater-roll": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-4.0.4.tgz",
+			"integrity": "sha512-KUs6zcvffHEUzgST+RmfZVagizjbX/AZFfDWQARxIaaPbNzwtnM6YWCLw3egSrSPI0yCPezk6PdAohKynj0a0Q==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/updater-rotate": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-4.0.4.tgz",
 			"integrity": "sha512-XS87LV3lsIwXXDza5LRtri5T5N+ig+QcZX5ERpzjHsqgyisNN6y2/UpzTUBKl2OyjBhfnM69R8BI+ly88WwMkg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/updater-size": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-4.0.4.tgz",
+			"integrity": "sha512-0ojFmKSnC8mENh+9O4QTzuYErnB7WKYogEVc7Pa4LYzV9fxHMAP+aBHRBUAtRWxfm7U2WOqteOjZ8FReJrhxNw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/updater-tilt": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-4.0.4.tgz",
+			"integrity": "sha512-mMp4Pd8Rrl2hHxsbMD+UqE/RpyzVNMe8p7fINNciKWorYE7UUFSmZrxlqvBUofAV/HgCei1OxhSPUcgBdToUDA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/updater-twinkle": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-4.0.4.tgz",
+			"integrity": "sha512-m2VtYa3j44FLsTdwntF3KjYqqyY5pRU5vCneXOhntKwvn8eUy83Yzw0ZaNNGLnXZGp4hN+c68qjy8CbvbVZH4A==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.4"
+			}
+		},
+		"node_modules/@tsparticles/updater-wobble": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-4.0.4.tgz",
+			"integrity": "sha512-o5Ja5+Sdqt5iGBuAvCOOYXOQaH2iJs7cVBa3jok98wX5N0neJ34SHFpNADQV48ubGz52UEOCX0ghxHcBfUGRTw==",
 			"license": "MIT",
 			"peerDependencies": {
 				"@tsparticles/engine": "4.0.4"
@@ -4901,6 +5095,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4918,6 +5115,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4935,6 +5135,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4952,6 +5155,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4969,6 +5175,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -4986,6 +5195,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -5003,6 +5215,9 @@
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5026,6 +5241,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5049,6 +5267,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5072,6 +5293,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5095,6 +5319,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5118,6 +5345,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -5422,9 +5652,9 @@
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.30",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.30.tgz",
-			"integrity": "sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==",
+			"version": "2.10.31",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+			"integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -6576,9 +6806,9 @@
 			"license": "ISC"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.357",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
-			"integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
+			"version": "1.5.359",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.359.tgz",
+			"integrity": "sha512-8lPELWuYZIWk7NDvCNthtmMw/7Q5Wu25NpM4djFMHBmk8DubPAtL4YTOp7ou0e7HyJtwkVlWv8XMLURnrtgJQw==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -6590,9 +6820,9 @@
 			"license": "MIT"
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.21.3",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
-			"integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+			"version": "5.21.4",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.4.tgz",
+			"integrity": "sha512-wE4fDO8OjJhrPFH69HUQStq5oKvGRTNXEyW+k5C/pUQLASSsTu7obd2V3GvCDgPcY9AWjhJ4jz9Kh7iRvrxhJg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8222,6 +8452,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -8243,6 +8476,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -8264,6 +8500,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -8285,6 +8524,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -9495,16 +9737,16 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260515.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260515.0.tgz",
-			"integrity": "sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==",
+			"version": "4.20260518.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260518.0.tgz",
+			"integrity": "sha512-jbvp43zWa66tuQ+P7bl7s25VJWzGMv4mVhxEEZEEATPvuqAQhGn2wj3rQViVZkZZBZmXQtZ5ZV5kX9VtmWGzuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "^0.34.5",
 				"undici": "7.24.8",
-				"workerd": "1.20260515.1",
+				"workerd": "1.20260518.1",
 				"ws": "8.18.0",
 				"youch": "4.1.0-beta.10"
 			},
@@ -9888,9 +10130,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.14",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+			"version": "8.5.15",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
 			"dev": true,
 			"funding": [
 				{
@@ -9908,7 +10150,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -10858,9 +11100,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.7",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
-			"integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
+			"version": "5.55.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.8.tgz",
+			"integrity": "sha512-4D6lyrMHmDaZalQOEBMCWCCidyZjSnec14/oPn0k627G6goxcck9xqMwz1tFLlQz+ZFvtTTHfFOlUayuAz0z6Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
@@ -11387,139 +11629,6 @@
 				"@tsparticles/updater-tilt": "4.0.4",
 				"@tsparticles/updater-twinkle": "4.0.4",
 				"@tsparticles/updater-wobble": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/interaction-external-drag": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-drag/-/interaction-external-drag-4.0.4.tgz",
-			"integrity": "sha512-CG7XE1jWKOM4+VzhLSbcfCqhaMMdDj1bauECWffme3vOekCU38mdGwNozcr7+WyCTfKKMadSqeLRcmpiYIJzLA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/plugin-absorbers": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-4.0.4.tgz",
-			"integrity": "sha512-LOJITOePmKi9V6rTDIVJmTcH9j9dS4OyVFmxt5tTdl7iQpVEMMwr9L8HVzNMcgcA+Iy6J1b/OW76UtNMhgBFww==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			},
-			"peerDependenciesMeta": {
-				"@tsparticles/plugin-interactivity": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/plugin-emitters": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-4.0.4.tgz",
-			"integrity": "sha512-ep4ElX2vrzreaWSqhSLzw+GYb/wh+743Al2Gdf+wR7ctqSrgDQYyKU27+nPRnUR+IF8CQ1tUBMsTl0oPPvUnvg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			},
-			"peerDependenciesMeta": {
-				"@tsparticles/plugin-interactivity": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/plugin-emitters-shape-circle": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-4.0.4.tgz",
-			"integrity": "sha512-wp6/RUOoNWU3AjNEXrX8RkTLCceHoRDQE2+NgLWcLviftEmTKQf3TX4TkXmp09NSSVtyIiyA4UUgN4P6ytwDGw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/matteobruni"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/tsparticles"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://www.buymeacoffee.com/matteobruni"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-emitters": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/plugin-emitters-shape-square": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-4.0.4.tgz",
-			"integrity": "sha512-SbvJj/kzMYn0cGeo/v4QQu6gOfrHd99xepIhKO79N99lCZAbqOPC+dqcBlPFw8PfRic+xmMJCwHW7IYlDuhAUw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/matteobruni"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/tsparticles"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://www.buymeacoffee.com/matteobruni"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-emitters": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/updater-destroy": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-4.0.4.tgz",
-			"integrity": "sha512-Wbw8avoK3YNP7waGYzTTblYsdccwlL+NpGyAl9ML+/went65qAqFpCE8h7N1pgfrhCArwYHf2FPmtXipSUOizA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/updater-roll": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-4.0.4.tgz",
-			"integrity": "sha512-KUs6zcvffHEUzgST+RmfZVagizjbX/AZFfDWQARxIaaPbNzwtnM6YWCLw3egSrSPI0yCPezk6PdAohKynj0a0Q==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/updater-tilt": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-4.0.4.tgz",
-			"integrity": "sha512-mMp4Pd8Rrl2hHxsbMD+UqE/RpyzVNMe8p7fINNciKWorYE7UUFSmZrxlqvBUofAV/HgCei1OxhSPUcgBdToUDA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/updater-twinkle": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-4.0.4.tgz",
-			"integrity": "sha512-m2VtYa3j44FLsTdwntF3KjYqqyY5pRU5vCneXOhntKwvn8eUy83Yzw0ZaNNGLnXZGp4hN+c68qjy8CbvbVZH4A==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/updater-wobble": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-4.0.4.tgz",
-			"integrity": "sha512-o5Ja5+Sdqt5iGBuAvCOOYXOQaH2iJs7cVBa3jok98wX5N0neJ34SHFpNADQV48ubGz52UEOCX0ghxHcBfUGRTw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
 			}
 		},
 		"node_modules/tweakpane": {
@@ -12346,9 +12455,9 @@
 			"license": "MIT"
 		},
 		"node_modules/workerd": {
-			"version": "1.20260515.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260515.1.tgz",
-			"integrity": "sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==",
+			"version": "1.20260518.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260518.1.tgz",
+			"integrity": "sha512-rLquk/eeqqJCbdGljSSuIZWW25vzYjTblXkD/tXQXKR5YsSIC91EtlqrzA1L4TJDZCxXKeFXPYqkW7R16UipXQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -12359,11 +12468,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260515.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260515.1",
-				"@cloudflare/workerd-linux-64": "1.20260515.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260515.1",
-				"@cloudflare/workerd-windows-64": "1.20260515.1"
+				"@cloudflare/workerd-darwin-64": "1.20260518.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260518.1",
+				"@cloudflare/workerd-linux-64": "1.20260518.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260518.1",
+				"@cloudflare/workerd-windows-64": "1.20260518.1"
 			}
 		},
 		"node_modules/worktop": {
@@ -12381,9 +12490,9 @@
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.92.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.92.0.tgz",
-			"integrity": "sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ==",
+			"version": "4.93.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.93.0.tgz",
+			"integrity": "sha512-qNsPr0oWRTc85SG7s1MjX+mWNTvkNV1zEQvRpTsV6eo8uqtvZoEAq8t8strQi9TtrDP3BOsxmy+N/G3ML6hH2w==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -12391,10 +12500,10 @@
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260515.0",
+				"miniflare": "4.20260518.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260515.1"
+				"workerd": "1.20260518.1"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
@@ -12407,7 +12516,7 @@
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260515.1"
+				"@cloudflare/workers-types": "^4.20260518.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -101,7 +101,7 @@
 		"@tsparticles/engine": "^4.0.4",
 		"@tsparticles/interaction-external-trail": "^4.0.4",
 		"@tsparticles/shape-text": "^4.0.4",
-		"@tsparticles/slim": "^4.0.2",
+		"@tsparticles/slim": "^4.0.4",
 		"apexcharts": "^5.12.0",
 		"arctic": "^3.7.0",
 		"cookie": "^1.1.1",


### PR DESCRIPTION
Bumps `@tsparticles/slim` from `^4.0.2` to `^4.0.4` in `webapp/package.json`.

This fixes an `npm install` failure (ERESOLVE) caused by conflicting peer dependencies, as other packages in the tree were expecting `@tsparticles/engine@4.0.4`. All `@tsparticles/*` dependencies are now correctly aligned on version `4.0.4`.

---
*PR created automatically by Jules for task [355824705104806442](https://jules.google.com/task/355824705104806442) started by @nickbrett1*