### PR TITLE
fix: resolve tsparticles peer dependency conflict

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -12,10 +12,10 @@
 				"@stripe/stripe-js": "^9.6.0",
 				"@threlte/core": "^8.5.14",
 				"@threlte/extras": "^9.18.0",
-				"@tsparticles/engine": "^4.0.4",
+				"@tsparticles/engine": "^4.0.5",
 				"@tsparticles/interaction-external-trail": "^4.0.5",
-				"@tsparticles/shape-text": "^4.0.4",
-				"@tsparticles/slim": "^4.0.4",
+				"@tsparticles/shape-text": "^4.0.5",
+				"@tsparticles/slim": "^4.0.5",
 				"apexcharts": "^5.12.0",
 				"arctic": "^3.7.0",
 				"cookie": "^1.1.1",
@@ -30,7 +30,7 @@
 				"stripe": "^22.1.1",
 				"three": "^0.184.0",
 				"tippy.js": "^6.3.7",
-				"tsparticles": "^4.0.4"
+				"tsparticles": "^4.0.5"
 			},
 			"devDependencies": {
 				"@cloudflare/vite-plugin": "^1.37.1",
@@ -3340,9 +3340,9 @@
 			}
 		},
 		"node_modules/@tsparticles/basic": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-4.0.4.tgz",
-			"integrity": "sha512-fXUoDgl55+dKpGKgdhNcj0f9rUX3ZZF5aaWSHG3b3poC/SjiL82GNYt/yeiHQGXnpK2tLJO3ZcbDVrlXB+WpSQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/basic/-/basic-4.0.5.tgz",
+			"integrity": "sha512-JWAsRUh8v8RYxLilAAlcwIvUlO2Jfl0DW2t+aAm0OAp4WjmebWSYeG+/CV6Ov+ynV/38vEDAYQIRpyG8Vpmyrg==",
 			"funding": [
 				{
 					"type": "github",
@@ -3359,23 +3359,23 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-blend": "4.0.4",
-				"@tsparticles/plugin-hex-color": "4.0.4",
-				"@tsparticles/plugin-hsl-color": "4.0.4",
-				"@tsparticles/plugin-move": "4.0.4",
-				"@tsparticles/plugin-rgb-color": "4.0.4",
-				"@tsparticles/shape-circle": "4.0.4",
-				"@tsparticles/updater-opacity": "4.0.4",
-				"@tsparticles/updater-out-modes": "4.0.4",
-				"@tsparticles/updater-paint": "4.0.4",
-				"@tsparticles/updater-size": "4.0.4"
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-blend": "4.0.5",
+				"@tsparticles/plugin-hex-color": "4.0.5",
+				"@tsparticles/plugin-hsl-color": "4.0.5",
+				"@tsparticles/plugin-move": "4.0.5",
+				"@tsparticles/plugin-rgb-color": "4.0.5",
+				"@tsparticles/shape-circle": "4.0.5",
+				"@tsparticles/updater-opacity": "4.0.5",
+				"@tsparticles/updater-out-modes": "4.0.5",
+				"@tsparticles/updater-paint": "4.0.5",
+				"@tsparticles/updater-size": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/canvas-utils": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/canvas-utils/-/canvas-utils-4.0.4.tgz",
-			"integrity": "sha512-ivLF6bWAFfJj8lyDvWTEbdAO5yPqrlkr0vFI3OorsUsMMru77ZrU5Vlr1Uw+yYQQ5RZNULIaAo+JQ996jylBdA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/canvas-utils/-/canvas-utils-4.0.5.tgz",
+			"integrity": "sha512-U/KtQBuv1reSTnpyBswp4SfhDjOSG9lvcR8Z+1FTV+5/Vfjz2hEy3p61dN934xffrY24uFJE1f60m1npwZ4Ayg==",
 			"funding": [
 				{
 					"type": "github",
@@ -3392,13 +3392,13 @@
 			],
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/engine": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-4.0.4.tgz",
-			"integrity": "sha512-o8tTj8mUJABm965uy0Y+Q2VuNWlIeAHrjdZNE6rkr2A/jnOruoKQMWyFrE6XPbOwz0bR3wU/dRaExExyUZSPhA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/engine/-/engine-4.0.5.tgz",
+			"integrity": "sha512-ovFQNzz18Ef0ww7wPqykHWU06K1EhTkMPZhoIZQQaRbFmKKoE+5LyTGGTZGzGjQ4GjHLZq7l9kGl1oInpzoK4Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -3416,6 +3416,142 @@
 			"hasInstallScript": true,
 			"license": "MIT"
 		},
+		"node_modules/@tsparticles/interaction-external-attract": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-4.0.5.tgz",
+			"integrity": "sha512-k/2/TGRhCEJHUTWjcarWzG2c4OdHKihkjrEaKaLNuLOtJr30IPAzD4WSs8TDUEFAh1lEKmpC3stbRcjMmHMnMQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-bounce": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-4.0.5.tgz",
+			"integrity": "sha512-p6KWrxFmhWXvae3HA3SpE5q8X7eVvPKpxbqjk+pK648zb20u8iCpD+7ahadkey10TxggC7ffAa20ATLGftchdw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-bubble": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-4.0.5.tgz",
+			"integrity": "sha512-rFBCF0oOD2bFDM/VmN1M/8LC114UXOvJSyAHmxB1z3N9u/S1MfQBz3nh98D6hTsYAyc9pKdaInDWqBQxabEmUw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-connect": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-4.0.5.tgz",
+			"integrity": "sha512-e9xmZGLI8C7yf+G9Bpbh30QxwXDJkbV16d012jrjVklRnT2iQvs6y2p1KGI3xTNWkyKAKnyIiXYRRSSvBgc4+Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/canvas-utils": "4.0.5"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-destroy": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-destroy/-/interaction-external-destroy-4.0.5.tgz",
+			"integrity": "sha512-AX9o1nytQVQdCvhSzF2fzJwVyG0dtSmWIgC1HBklCoARmyydyWOJ2rt0/4sPCu0RjEYeUDI6LSTzzCy6LSJaTw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-drag": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-drag/-/interaction-external-drag-4.0.5.tgz",
+			"integrity": "sha512-NnRIznf0rlhSvPlTI0GIxp3lDVhgz8fQgHOky8rRT4+7NYJcPzlMXMRQHA0CQ1W2mX6a/mREb6f3FbF55xwDAA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-grab": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-4.0.5.tgz",
+			"integrity": "sha512-xa+zfluNw+nhoNxBbqeM62QYvfb0NV+gt91R/1bYHJb8CmflBiYhLX5kO3dsGu/zzpjnccqnEN5UDnvPKO8niQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/canvas-utils": "4.0.5"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-parallax": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-parallax/-/interaction-external-parallax-4.0.5.tgz",
+			"integrity": "sha512-arNHolnrksrbeLjDZbVDStwgNZAudkRoC3BnR+a2bzVEyGQnix/3MVT+N1PnrSnd0KuXN+yec+N3MlU91aJ2FQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-pause": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-4.0.5.tgz",
+			"integrity": "sha512-ehMtDvISL40Sr8cQ6vqv67LjwV9xj92OI7RkigTViJiwC4+GNv+3mdEb9Nn/dBphuQ2LmjZAc9b7FfPmBoKIdQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-push": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-4.0.5.tgz",
+			"integrity": "sha512-XmDUE7HoAIJf9MFC+7WBuEvTk9RfXyLSLFWxRmyEapy4AMDUyWR8DhZU+yslj440W1J0rq28vPOjsOYUwvY9tQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-remove": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-4.0.5.tgz",
+			"integrity": "sha512-Vd3KWTPwmguAJR1xmwrYwv7ItFL7xqxDzTS0YfDwtm7glXQG/Uo8lszxcASQTw6DNvSG6opGisGlO+dGSX0uJw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-repulse": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-4.0.5.tgz",
+			"integrity": "sha512-Fpd8PBJDRcBohuJbwpr99annMWVVuct5EPiTRsyigshrERpFr4xDHPodhgVJ6A9IFs0NGMH5Kfa1WReSsM8tCA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-external-slow": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-4.0.5.tgz",
+			"integrity": "sha512-u1RFBXmsOWVPnmdgOsgI3Usg8By0u+xARS1faU+DeQx0UCZeVTbRKR9/f+afcP36EVGb9y5Ij4+zjq5M84dmbA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
 		"node_modules/@tsparticles/interaction-external-trail": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-trail/-/interaction-external-trail-4.0.5.tgz",
@@ -3426,19 +3562,67 @@
 				"@tsparticles/plugin-interactivity": "4.0.5"
 			}
 		},
-		"node_modules/@tsparticles/plugin-blend": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-blend/-/plugin-blend-4.0.4.tgz",
-			"integrity": "sha512-XY0AvvESoXQS6pVJD7kez8oORzfbI4hzlqCMTPwCsiWFP3f7uUnQyz+3R1KLC33jqZQhpzalFf9G0wTj2Egr3Q==",
+		"node_modules/@tsparticles/interaction-particles-attract": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-4.0.5.tgz",
+			"integrity": "sha512-1FWdRXB32s1LUrV7u0D+mu88WxRq8ijmUfqTlEHMPX/nNPKoSRbic4pN1fTxdbH9hD21S+rjECBmaLmEzpqnVg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-particles-collisions": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-4.0.5.tgz",
+			"integrity": "sha512-kF5f/7xnjj3tPFUFxuPe2TX8Ee0ZNJskvU0gXjNb6UER9WuvK596gkJWxeWib8VMyKgAywyV0Mp/hXQh0YsJRw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/interaction-particles-links": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-4.0.5.tgz",
+			"integrity": "sha512-06+CKi4DwbmBwoIuHc/PTpnI7V7loqFgmddY16xPXzDs5i9W/Uhhovg5d5yplFOTxmiNLF9QY0Yz6aMHZ3f7cQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tsparticles/canvas-utils": "4.0.5"
+			},
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/plugin-absorbers": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-4.0.5.tgz",
+			"integrity": "sha512-GZgbsswDRZ/VnfKJ7iOglrYTiN004K/7uH9LdMnL7MJzbATzY6dHtLRfmxEMPcorocYtWIc7+9uXvHbU2SnatQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			},
+			"peerDependenciesMeta": {
+				"@tsparticles/plugin-interactivity": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tsparticles/plugin-blend": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-blend/-/plugin-blend-4.0.5.tgz",
+			"integrity": "sha512-7w21hS28GnD4ac5uooRskmMprFUCJs6wHveC4CY5XiiE7ldcHTUMNT9b2fwXMFawBZDSezfjhCms7zhIQDbjgg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/plugin-easing-quad": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-4.0.4.tgz",
-			"integrity": "sha512-OxG8ec3VqbnGRigQF0Bd/V523q7WfwFut8xhYKHUJsbRqX9a4RrqLCU728XXeOSyeg61sSvlUqIsVSLumrmYIQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-easing-quad/-/plugin-easing-quad-4.0.5.tgz",
+			"integrity": "sha512-CsRCndjCeRAUAz+l7zrYEWdw8JK7gbNBxnq5sRcaflESDLNtyeZQtkYoVsMouUgbr4/UdShLMi1IqQiR117vpw==",
 			"funding": [
 				{
 					"type": "github",
@@ -3455,13 +3639,76 @@
 			],
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/plugin-emitters": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-4.0.5.tgz",
+			"integrity": "sha512-Hf0ufMHnP5FlWIymnXsiAl4+plEd/sa8OW8kfRyw17RhXeubPDZZv8er36KDh/JkVZoA8DeCG+FlIvwSk2+uSg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5"
+			},
+			"peerDependenciesMeta": {
+				"@tsparticles/plugin-interactivity": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tsparticles/plugin-emitters-shape-circle": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-4.0.5.tgz",
+			"integrity": "sha512-jQK4h2gvPxQCCfZjEImivK/j1PlJijMcmY1yUxFeCEp8Fa7YgkwTAcxOxNmf/JZOvctrc08CZWtq2eS6ihQ1Xg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/matteobruni"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/tsparticles"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://www.buymeacoffee.com/matteobruni"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-emitters": "4.0.5"
+			}
+		},
+		"node_modules/@tsparticles/plugin-emitters-shape-square": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-4.0.5.tgz",
+			"integrity": "sha512-ehyP8maJhrWINcrc4bvml3x5hmNP/dtC9DurxNo065pf1NxqDim1v+Ldm0Sdk9nnlJqDa6fy5soO48+Y4QpE5Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/matteobruni"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/tsparticles"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://www.buymeacoffee.com/matteobruni"
+				}
+			],
+			"license": "MIT",
+			"peerDependencies": {
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/plugin-emitters": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/plugin-hex-color": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-4.0.4.tgz",
-			"integrity": "sha512-x9l+4tqQkBBbEQN2msasC+Hqe/ojNWz1JEIp0dK7NYGMgaY9ooug+IvoQazNut3ke2R9yFUoU8lj3OEZ6GE+Wg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hex-color/-/plugin-hex-color-4.0.5.tgz",
+			"integrity": "sha512-GWmkiiSlb4oow1OxJQF32R2ulOhMwToQvexJC7oqd/2yxZuScD7fukpM5kv9S9XhKVE+zjOJHeWIhRFrBl7mCQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -3478,13 +3725,13 @@
 			],
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/plugin-hsl-color": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-4.0.4.tgz",
-			"integrity": "sha512-3Rh5malxB+dtdkGmqh470OFfelL//Qr3HKj8jukkEnpiTfDjpgNEscISDymxLdb8H06vQzFP8s1eo4ZAsPGLgQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-hsl-color/-/plugin-hsl-color-4.0.5.tgz",
+			"integrity": "sha512-gdey7PUKPijnG9hIfrD3z8N4xjyOyRWXsvaGXhoMgpaD47Vcc/wsIXmx/0Znsct0cEEXByXoMQyM8MRO1yTg0w==",
 			"funding": [
 				{
 					"type": "github",
@@ -3501,7 +3748,7 @@
 			],
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/plugin-interactivity": {
@@ -3509,24 +3756,23 @@
 			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-interactivity/-/plugin-interactivity-4.0.5.tgz",
 			"integrity": "sha512-tRTvH5/MUy/3MNG344rBNuTFxLVCo9MaiYU3d0cxg9Xuh1jVOsIcNj3KbQrOdYvFowzVml8+cAeMGfLtsQoyDw==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/plugin-move": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-move/-/plugin-move-4.0.4.tgz",
-			"integrity": "sha512-JOP+0caRlF3Uf6+QvfncOcgHRf2S+d6EJtCktK/7aWobKWlEbXkRAkAHOi91VKVPanDUhxe50prduzTG5OJddw==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-move/-/plugin-move-4.0.5.tgz",
+			"integrity": "sha512-IJVS/f7QHEfGz4LSlidAmLPPGc2Jj1vp6ydxvMOIyjzPrxS8PIYqsXB0jWjy2fr5KT6+VCNDX+7fY8v0EK9OOg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/plugin-rgb-color": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-4.0.4.tgz",
-			"integrity": "sha512-Dd8nw4e5Hs8HOj8IjuM3hqyeZY6l300qifOu6ZpV/viE5hKFtB/EfkQOMjG2bmsO/MH1LuNeLakTk3wxpGbywg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-rgb-color/-/plugin-rgb-color-4.0.5.tgz",
+			"integrity": "sha512-+JDxQWW1WupxnDwvN+C0vWQmOvBFkvtvK2MJ6qNjOI9/7Nj8s0xzwm5KGqVUWkaF16K3+AihNjEQRb/M8E5skg==",
 			"funding": [
 				{
 					"type": "github",
@@ -3543,91 +3789,91 @@
 			],
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/shape-circle": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-4.0.4.tgz",
-			"integrity": "sha512-upauaL03H+llIRu6vgpUpxHRpOFalF9nYY9u2LYUBSka4+z0Qp5iqx1/IuPyqwZ5mZBbAntoC05k6PB7LGmaIw==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-circle/-/shape-circle-4.0.5.tgz",
+			"integrity": "sha512-y2CcWNCnC2m2/DaE5CsWbJSCjKsLbOySdT9qgyezmT/boYHupJuNNNOeXP56Tlq+je1wZpayCIAKOpl+VhBtiw==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/shape-emoji": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-4.0.4.tgz",
-			"integrity": "sha512-lq4pgf5u8qXKsuzpZxOvz6s1zbnhItY1lfprS0x30y26I5QfzThcEVayXCf/Jj33KIMe79uyPLtY1H3vVVrOIA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-emoji/-/shape-emoji-4.0.5.tgz",
+			"integrity": "sha512-OyEtJ+tspbIQz21S2aUReH1yllIsZ8eAQ+OthcXllviS43hUSjlNdhsYhlJquIX4pU4UixpMaNngM2CaUDb4RQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.4"
+				"@tsparticles/canvas-utils": "4.0.5"
 			},
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/shape-image": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-4.0.4.tgz",
-			"integrity": "sha512-KSWHMvv04ffEapmFf8HjF1nwvCm8Q7OPEAKZoTMThvNN9RMKneb2gQkxjU1HQWViQIJzgJ2jPBsNwYXRpGewyg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-image/-/shape-image-4.0.5.tgz",
+			"integrity": "sha512-2tmJly5jLDJo8MtWOYbBTy07h7cZQ3vMLbux4frANBVgUJxipKl4DK0o2uXx0Qq7g+yMOObIPb17GR8FC2KQdg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/shape-line": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-4.0.4.tgz",
-			"integrity": "sha512-jzixuwuIPKeJA7BObAFmcHyYy3/Vfp3qDkDqtlpLHW7vmifZmdZ0xYMoIumLfvPUvUUMvXQwk3M53CmrR1XPng==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-line/-/shape-line-4.0.5.tgz",
+			"integrity": "sha512-5pcbqrkH1l9spGV7nYpfEiA94NlZYGYUEBP8x/Hk4SIyvV1085ewonDj+fPcoOad27JXaq076xZlqJZMxo/9WA==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/shape-polygon": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-4.0.4.tgz",
-			"integrity": "sha512-+wV3lgmSzzQAEbEnP5NKzIpWJcYuL7JsI2XyUW1zl7wuWT1SmjgSu1zRPJG7/v2J3BMKnRp+yFzNHQBOrRm5/g==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-polygon/-/shape-polygon-4.0.5.tgz",
+			"integrity": "sha512-RZwLXtSsnX/KC8Jxjlvp/eSBPs7pU9uN06peWGsteqFUteuMMaCvTPzNpOX0yevDsDKWj8YOklaD89GjrEZ1GQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/shape-square": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-4.0.4.tgz",
-			"integrity": "sha512-3lemqnG3iuHOmRQT5gW5IRZmZ80bXt6oGqqm9wpnWiHeAbGP60VV1D5fnO66QiEFj7oOg55iOT9J7gYeo9QMwQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-square/-/shape-square-4.0.5.tgz",
+			"integrity": "sha512-TMwvEp81/RhJfwRQM/Z7/D56ZZX8RbKd+8OT2DFtk1RJ0OMp+JQT3untwU0rV5pbQsazrlFWj5pnUk5Dy1kTlQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/shape-star": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-4.0.4.tgz",
-			"integrity": "sha512-ow3HP1D5q1WNyqp1y+95qUzLniUIbMxAUNxgz5m9Q+Hvws/dV1XN8OLbyfCSg8q6K4fbQuCTQv/ReUitBm/oBg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-star/-/shape-star-4.0.5.tgz",
+			"integrity": "sha512-Gg9kg3iTDywyN0PSTliQFa6CFdS4vtTRnSw7Yi1ofAL8KDQHzakpLHoRnKeJJudFHtLOQgJkX7/jVG1yZ82nbw==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/shape-text": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-4.0.4.tgz",
-			"integrity": "sha512-fwVWiQkwk/adLv2UuNst/+iyU/zYww3UT7r+7sMB0OqPgqMvm4paBHgNCEOZZYNKEFzJCKRRTOW+au/piwAKEA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/shape-text/-/shape-text-4.0.5.tgz",
+			"integrity": "sha512-0fDNypCb1iS8xj0l5mQFU4GmmYzoTwJmtA/TBERNGZRQGirqnMHV1ro/o/u2bOyS98TlFGvf3MW6EcV9QD+1tw==",
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.4"
+				"@tsparticles/canvas-utils": "4.0.5"
 			},
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/slim": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-4.0.4.tgz",
-			"integrity": "sha512-RgR9214v9qEfUOIg3iiIxDPQY2+96BNPB3bdIFAR92nkN3lTEinmZ2Zo2Re79JKrW4EE+Vd3ZyGdx+8Vm8CAUA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/slim/-/slim-4.0.5.tgz",
+			"integrity": "sha512-W90wnex7dZsYszd+J98IoKUX5U+7Q53r9USsPl8edpY1vNJvJh0VijY5Hbi1KTIbG1w/9DCn7HAvMLRyv99gYQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -3644,301 +3890,133 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/basic": "4.0.4",
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/interaction-external-attract": "4.0.4",
-				"@tsparticles/interaction-external-bounce": "4.0.4",
-				"@tsparticles/interaction-external-bubble": "4.0.4",
-				"@tsparticles/interaction-external-connect": "4.0.4",
-				"@tsparticles/interaction-external-destroy": "4.0.4",
-				"@tsparticles/interaction-external-grab": "4.0.4",
-				"@tsparticles/interaction-external-parallax": "4.0.4",
-				"@tsparticles/interaction-external-pause": "4.0.4",
-				"@tsparticles/interaction-external-push": "4.0.4",
-				"@tsparticles/interaction-external-remove": "4.0.4",
-				"@tsparticles/interaction-external-repulse": "4.0.4",
-				"@tsparticles/interaction-external-slow": "4.0.4",
-				"@tsparticles/interaction-particles-attract": "4.0.4",
-				"@tsparticles/interaction-particles-collisions": "4.0.4",
-				"@tsparticles/interaction-particles-links": "4.0.4",
-				"@tsparticles/plugin-easing-quad": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4",
-				"@tsparticles/shape-emoji": "4.0.4",
-				"@tsparticles/shape-image": "4.0.4",
-				"@tsparticles/shape-line": "4.0.4",
-				"@tsparticles/shape-polygon": "4.0.4",
-				"@tsparticles/shape-square": "4.0.4",
-				"@tsparticles/shape-star": "4.0.4",
-				"@tsparticles/updater-life": "4.0.4",
-				"@tsparticles/updater-paint": "4.0.4",
-				"@tsparticles/updater-rotate": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-attract": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-attract/-/interaction-external-attract-4.0.4.tgz",
-			"integrity": "sha512-QSTvaPdaRQd6OSUNJ33JoOz3iIOQMFdmnaqR4TDo5T3p+0dqkGuDWxj08ckjNIfiqbZZKpO3hLcbRtkYsKWJew==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-bounce": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bounce/-/interaction-external-bounce-4.0.4.tgz",
-			"integrity": "sha512-MiqAI67mZpQzSWkwhBGkdb2nGP2QsuEBBgSX46ouU7M0/Ew1CDEyQVK9eKn7tAWldUoDLF4M8c02eF/ovAfByg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-bubble": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-bubble/-/interaction-external-bubble-4.0.4.tgz",
-			"integrity": "sha512-VqL17FA3CYoNEOZ1zbvbD1sZsSIXtk2bEPfcUc2DTrdJmmYBQxfUwqb1WMSYmFqI/M3fRJbY4hzltwJig/1i4A==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-connect": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-connect/-/interaction-external-connect-4.0.4.tgz",
-			"integrity": "sha512-BlMYsk/+70MviAmDq0Eabbke6e5X9XfLn83lq4QzaRNc0B+2WEORQp/TWzdNKupssgTvxoqmTtTtccWC/QqoTw==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.4"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-destroy": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-destroy/-/interaction-external-destroy-4.0.4.tgz",
-			"integrity": "sha512-LIio2HVWRpcbvHPUP+oYF3kaeE+KJYLxLgJVMENuvUCxdxTk5e1vpWtaKjes8Wu8X81r0x0x1G5rkkXrn11oAg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-grab": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-grab/-/interaction-external-grab-4.0.4.tgz",
-			"integrity": "sha512-NTlei1BRaxWEreXYSevSEw3B0gwPUJQshKe9fY6XT8MkNrrmY0dybUxpOj1CfmUk54UqiUQ733n+MIwAueX3Og==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.4"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-parallax": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-parallax/-/interaction-external-parallax-4.0.4.tgz",
-			"integrity": "sha512-33W9nvbMkgDDrez0TU2UFiBCwRsjZdmHbGIZy08O2cuk6EqR2AvGEguzE+UNXl42tUzWyO+fWlPs/K+Q2ngn2A==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-pause": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-pause/-/interaction-external-pause-4.0.4.tgz",
-			"integrity": "sha512-EVY+84Q2K4fzs+ddKZ3vKelZkrGhNzjyPkSMgg+xNkpaYQmA0w3kPH5oKgv4+tHXD/FN0ADt0SLGL3KisSN5CA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-push": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-push/-/interaction-external-push-4.0.4.tgz",
-			"integrity": "sha512-MvuINaQViTOtnuAHcfVoOC+63tvW/qnXzETGYUjeGtJo/19mHhfLruOrE6t/WELULXSAplfx7aGpVbsy/4MY1w==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-remove": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-remove/-/interaction-external-remove-4.0.4.tgz",
-			"integrity": "sha512-3eN6Fb17alU6q9f4JFA/ysOQCP/echTElET+siBu3q86sB6Zg8AXZiOlDa5sa1fAi1NaN7SUioKoRa3u8alNsA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-repulse": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-repulse/-/interaction-external-repulse-4.0.4.tgz",
-			"integrity": "sha512-pA/t84Ngq/HNOhHLAQpZx1YB5Jmd9JEdu4XloPw6WSgF2zlTTue+fQ6kOyMLURstnE2Xrw6l2Hh8SUJsn8UfZg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-external-slow": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-slow/-/interaction-external-slow-4.0.4.tgz",
-			"integrity": "sha512-QKRmhxUQCeK/NUI5AHKc4FTAwkZp1EdCNIsOub6PdLyU2xSXbMtCQR8unt+njUGQtS2DHZ1MCuG6yU3rEwNTxA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-particles-attract": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-attract/-/interaction-particles-attract-4.0.4.tgz",
-			"integrity": "sha512-V2kgBzXawt9LQvNBfmrnl0lossfs0gcSllmuVPjh1EgeFxdRtcwMKB0G73zGXt76PnEJTwCJXmdj44QhD6KEsg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-particles-collisions": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-collisions/-/interaction-particles-collisions-4.0.4.tgz",
-			"integrity": "sha512-uz1n7XO7+N4WjnACuzVDlUK2A4FBbMqym7UG2dCg3er+axEfwa3gbhDk+wTSUM11V6FxR9HVCPLqyAh54pn2dQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/interaction-particles-links": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-particles-links/-/interaction-particles-links-4.0.4.tgz",
-			"integrity": "sha512-mjN1DhACIHvOQNv0YkJMLytlKdq1cOfy+MkHeGIYLBWVUJEF26ol+mQi/9C11ffcPmug1eVlcl0CQdGcYD7rpQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@tsparticles/canvas-utils": "4.0.4"
-			},
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/@tsparticles/slim/node_modules/@tsparticles/plugin-interactivity": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-interactivity/-/plugin-interactivity-4.0.4.tgz",
-			"integrity": "sha512-e3NdfGJbE5aAW1ukd+fiPesmHtkmbGB2AfAVDXiAxRdAy/NqaqZqAHCPCPxAqYNCx+j9JkqOLxmWXEelVFXppQ==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/basic": "4.0.5",
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/interaction-external-attract": "4.0.5",
+				"@tsparticles/interaction-external-bounce": "4.0.5",
+				"@tsparticles/interaction-external-bubble": "4.0.5",
+				"@tsparticles/interaction-external-connect": "4.0.5",
+				"@tsparticles/interaction-external-destroy": "4.0.5",
+				"@tsparticles/interaction-external-grab": "4.0.5",
+				"@tsparticles/interaction-external-parallax": "4.0.5",
+				"@tsparticles/interaction-external-pause": "4.0.5",
+				"@tsparticles/interaction-external-push": "4.0.5",
+				"@tsparticles/interaction-external-remove": "4.0.5",
+				"@tsparticles/interaction-external-repulse": "4.0.5",
+				"@tsparticles/interaction-external-slow": "4.0.5",
+				"@tsparticles/interaction-particles-attract": "4.0.5",
+				"@tsparticles/interaction-particles-collisions": "4.0.5",
+				"@tsparticles/interaction-particles-links": "4.0.5",
+				"@tsparticles/plugin-easing-quad": "4.0.5",
+				"@tsparticles/plugin-interactivity": "4.0.5",
+				"@tsparticles/shape-emoji": "4.0.5",
+				"@tsparticles/shape-image": "4.0.5",
+				"@tsparticles/shape-line": "4.0.5",
+				"@tsparticles/shape-polygon": "4.0.5",
+				"@tsparticles/shape-square": "4.0.5",
+				"@tsparticles/shape-star": "4.0.5",
+				"@tsparticles/updater-life": "4.0.5",
+				"@tsparticles/updater-paint": "4.0.5",
+				"@tsparticles/updater-rotate": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-destroy": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-4.0.4.tgz",
-			"integrity": "sha512-Wbw8avoK3YNP7waGYzTTblYsdccwlL+NpGyAl9ML+/went65qAqFpCE8h7N1pgfrhCArwYHf2FPmtXipSUOizA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-destroy/-/updater-destroy-4.0.5.tgz",
+			"integrity": "sha512-W3HZzxQ5CYTHIknnX2jviMZeNMbz5vyb9JJGvjretxHbfryce314Su2T0Dos/ym21qqOyfs9AGoLKaY/SCKZYA==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-life": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-4.0.4.tgz",
-			"integrity": "sha512-aDDjOHq/B6oQ9az+Q89NLoaMCeqgRyo+0a6eFooa+UycJyzZTNI7VwUecW/1/LpEFdiVD9qKjzbf8VJLMlVMDQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-life/-/updater-life-4.0.5.tgz",
+			"integrity": "sha512-ncBXJ6HljAK6ddMkjh0NQu2IrkC6IGBtPn6cH+/74kn1S2Aa4m8pOlQzUbvSbvT9NRoLDaWp+/M1vn+Wx8ISvQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-opacity": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-4.0.4.tgz",
-			"integrity": "sha512-pbAAjBlWOz/0UBk0eZUHTvWvyAabZd6Re5lDefmpTHYyCdb7QgWxxpgqZ5u/bEVDZO8ju1LH+7Rwe27BLNsSNQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-opacity/-/updater-opacity-4.0.5.tgz",
+			"integrity": "sha512-VNuJyLleqRgRfefmTbTg8bnCEyg1I24zJ46y9TMXwzklrz7A/7go94bt/0SO1nUGpRkOhJ06/2LkRrN1dH4gSQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-out-modes": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-4.0.4.tgz",
-			"integrity": "sha512-nraXjh7ww2BQFp0eK3oDpj4M8+el8CIQNUGVxxfghzERquWMUC/VROwYf5w7cljOEldDdk/NyXQrsOEMxA0fAQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-out-modes/-/updater-out-modes-4.0.5.tgz",
+			"integrity": "sha512-1SeMXkvEfJB5v6AeMVB2qFXzvzOMLMAhKfgQ4IJpnOttjKEAOn/ATq9t7HGPlaR2yL/uC2X1awyNmKs2U6nuJg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-paint": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-paint/-/updater-paint-4.0.4.tgz",
-			"integrity": "sha512-aoEHubEgOHRdk+EhaSC51Rm+D0+/5rmkrRUXcdM3snaejXyGtGcUZiZlczZeGHd5gxW9Nxn0Y0SQcWtHLai8VA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-paint/-/updater-paint-4.0.5.tgz",
+			"integrity": "sha512-wb2jdSOwkCaosZqvXicwYn/QADXbQlrGy6EqImX9Mdplssq8wlVGEe8DjfFFhVtbq7w4mY7mXis1rhPRYYzZGg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-roll": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-4.0.4.tgz",
-			"integrity": "sha512-KUs6zcvffHEUzgST+RmfZVagizjbX/AZFfDWQARxIaaPbNzwtnM6YWCLw3egSrSPI0yCPezk6PdAohKynj0a0Q==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-roll/-/updater-roll-4.0.5.tgz",
+			"integrity": "sha512-HdM+XqU99jKd0biA1QDacPin+5mFXZL2/DjX5Qn5wYfw3tB3q1R9a5/vK7b47h9tGLS6Ch+7aamTRBQ3b/YFaw==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-rotate": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-4.0.4.tgz",
-			"integrity": "sha512-XS87LV3lsIwXXDza5LRtri5T5N+ig+QcZX5ERpzjHsqgyisNN6y2/UpzTUBKl2OyjBhfnM69R8BI+ly88WwMkg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-rotate/-/updater-rotate-4.0.5.tgz",
+			"integrity": "sha512-9uMiwrumR0UQeqKYAx8dzLMdvaqH3aqzP8zK0d5Goib0fVaQaiILdNIHqMGiH/PjJ4JuGTtV5KqeFEwdSCFQ9Q==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-size": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-4.0.4.tgz",
-			"integrity": "sha512-0ojFmKSnC8mENh+9O4QTzuYErnB7WKYogEVc7Pa4LYzV9fxHMAP+aBHRBUAtRWxfm7U2WOqteOjZ8FReJrhxNw==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-size/-/updater-size-4.0.5.tgz",
+			"integrity": "sha512-MNCJph1o0uwdOXrFQ2myXd3gtn8MnqKb2XMCEZfYRcnGvxzoTPo8H2IH3wqebagj5u8Ah0pk0yWmvBW0239kfQ==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-tilt": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-4.0.4.tgz",
-			"integrity": "sha512-mMp4Pd8Rrl2hHxsbMD+UqE/RpyzVNMe8p7fINNciKWorYE7UUFSmZrxlqvBUofAV/HgCei1OxhSPUcgBdToUDA==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-tilt/-/updater-tilt-4.0.5.tgz",
+			"integrity": "sha512-zCpTdbrQ8a1KAY12tgQsHfK1m4Tqz5C901YiuZ3L52zNFH36noPsMxVELjexCbZeUMSM0DylC66Lf2HG1ExG1A==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-twinkle": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-4.0.4.tgz",
-			"integrity": "sha512-m2VtYa3j44FLsTdwntF3KjYqqyY5pRU5vCneXOhntKwvn8eUy83Yzw0ZaNNGLnXZGp4hN+c68qjy8CbvbVZH4A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-twinkle/-/updater-twinkle-4.0.5.tgz",
+			"integrity": "sha512-BBYHjhZ2cbZ/qAZyx6QWq2xolihyRAZ3lBsFtxC9MEifenuHo2gBiwdxBdv2E8vG4QO3Q7a7HOYwgy2aecyxfg==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tsparticles/updater-wobble": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-4.0.4.tgz",
-			"integrity": "sha512-o5Ja5+Sdqt5iGBuAvCOOYXOQaH2iJs7cVBa3jok98wX5N0neJ34SHFpNADQV48ubGz52UEOCX0ghxHcBfUGRTw==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@tsparticles/updater-wobble/-/updater-wobble-4.0.5.tgz",
+			"integrity": "sha512-ml8o2Wv61QQJ2hwkVLoxowHWZzJ1bFpZ7ydzf/9S5uyYMJ41GUDSUN2bKZO+gvsS1B+kKtO/3vUEjKmPD6ke9w==",
 			"license": "MIT",
 			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5"
 			}
 		},
 		"node_modules/@tweenjs/tween.js": {
@@ -11377,9 +11455,9 @@
 			"license": "0BSD"
 		},
 		"node_modules/tsparticles": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-4.0.4.tgz",
-			"integrity": "sha512-JZSpbYqAynKCs5/v8cyvI8o1UwkvPk/qKmnxcTNdbVRJWjU3GEahzGY+WTbyuaVCMBOUm7KB0IjOzaQI1TRFPQ==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-4.0.5.tgz",
+			"integrity": "sha512-vz2gSbGGaUw0J3QwXKnW9mc12RB+1BmFVPss/lS53hRrieGcIkMkOv4KYOIy84a+6aMMBqXzU1eEH2KbIzVxcQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -11396,128 +11474,20 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/interaction-external-drag": "4.0.4",
-				"@tsparticles/interaction-external-trail": "4.0.4",
-				"@tsparticles/plugin-absorbers": "4.0.4",
-				"@tsparticles/plugin-emitters": "4.0.4",
-				"@tsparticles/plugin-emitters-shape-circle": "4.0.4",
-				"@tsparticles/plugin-emitters-shape-square": "4.0.4",
-				"@tsparticles/shape-text": "4.0.4",
-				"@tsparticles/slim": "4.0.4",
-				"@tsparticles/updater-destroy": "4.0.4",
-				"@tsparticles/updater-roll": "4.0.4",
-				"@tsparticles/updater-tilt": "4.0.4",
-				"@tsparticles/updater-twinkle": "4.0.4",
-				"@tsparticles/updater-wobble": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/interaction-external-drag": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-drag/-/interaction-external-drag-4.0.4.tgz",
-			"integrity": "sha512-CG7XE1jWKOM4+VzhLSbcfCqhaMMdDj1bauECWffme3vOekCU38mdGwNozcr7+WyCTfKKMadSqeLRcmpiYIJzLA==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/interaction-external-trail": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/interaction-external-trail/-/interaction-external-trail-4.0.4.tgz",
-			"integrity": "sha512-+k74vXIXAEvCI6ro1CYhPnkIgGNNnLuG2TDNiDHL0JWF37dy3KRL4y3rwa1yYh05ff+DeCNH2j/VwwG5MvEjKg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/plugin-absorbers": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-absorbers/-/plugin-absorbers-4.0.4.tgz",
-			"integrity": "sha512-LOJITOePmKi9V6rTDIVJmTcH9j9dS4OyVFmxt5tTdl7iQpVEMMwr9L8HVzNMcgcA+Iy6J1b/OW76UtNMhgBFww==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			},
-			"peerDependenciesMeta": {
-				"@tsparticles/plugin-interactivity": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/plugin-emitters": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters/-/plugin-emitters-4.0.4.tgz",
-			"integrity": "sha512-ep4ElX2vrzreaWSqhSLzw+GYb/wh+743Al2Gdf+wR7ctqSrgDQYyKU27+nPRnUR+IF8CQ1tUBMsTl0oPPvUnvg==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-interactivity": "4.0.4"
-			},
-			"peerDependenciesMeta": {
-				"@tsparticles/plugin-interactivity": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/plugin-emitters-shape-circle": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-circle/-/plugin-emitters-shape-circle-4.0.4.tgz",
-			"integrity": "sha512-wp6/RUOoNWU3AjNEXrX8RkTLCceHoRDQE2+NgLWcLviftEmTKQf3TX4TkXmp09NSSVtyIiyA4UUgN4P6ytwDGw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/matteobruni"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/tsparticles"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://www.buymeacoffee.com/matteobruni"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-emitters": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/plugin-emitters-shape-square": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-emitters-shape-square/-/plugin-emitters-shape-square-4.0.4.tgz",
-			"integrity": "sha512-SbvJj/kzMYn0cGeo/v4QQu6gOfrHd99xepIhKO79N99lCZAbqOPC+dqcBlPFw8PfRic+xmMJCwHW7IYlDuhAUw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/matteobruni"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/tsparticles"
-				},
-				{
-					"type": "buymeacoffee",
-					"url": "https://www.buymeacoffee.com/matteobruni"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4",
-				"@tsparticles/plugin-emitters": "4.0.4"
-			}
-		},
-		"node_modules/tsparticles/node_modules/@tsparticles/plugin-interactivity": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@tsparticles/plugin-interactivity/-/plugin-interactivity-4.0.4.tgz",
-			"integrity": "sha512-e3NdfGJbE5aAW1ukd+fiPesmHtkmbGB2AfAVDXiAxRdAy/NqaqZqAHCPCPxAqYNCx+j9JkqOLxmWXEelVFXppQ==",
-			"license": "MIT",
-			"peer": true,
-			"peerDependencies": {
-				"@tsparticles/engine": "4.0.4"
+				"@tsparticles/engine": "4.0.5",
+				"@tsparticles/interaction-external-drag": "4.0.5",
+				"@tsparticles/interaction-external-trail": "4.0.5",
+				"@tsparticles/plugin-absorbers": "4.0.5",
+				"@tsparticles/plugin-emitters": "4.0.5",
+				"@tsparticles/plugin-emitters-shape-circle": "4.0.5",
+				"@tsparticles/plugin-emitters-shape-square": "4.0.5",
+				"@tsparticles/shape-text": "4.0.5",
+				"@tsparticles/slim": "4.0.5",
+				"@tsparticles/updater-destroy": "4.0.5",
+				"@tsparticles/updater-roll": "4.0.5",
+				"@tsparticles/updater-tilt": "4.0.5",
+				"@tsparticles/updater-twinkle": "4.0.5",
+				"@tsparticles/updater-wobble": "4.0.5"
 			}
 		},
 		"node_modules/tweakpane": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -98,10 +98,10 @@
 		"@stripe/stripe-js": "^9.6.0",
 		"@threlte/core": "^8.5.14",
 		"@threlte/extras": "^9.18.0",
-		"@tsparticles/engine": "^4.0.4",
+		"@tsparticles/engine": "^4.0.5",
 		"@tsparticles/interaction-external-trail": "^4.0.5",
-		"@tsparticles/shape-text": "^4.0.4",
-		"@tsparticles/slim": "^4.0.4",
+		"@tsparticles/shape-text": "^4.0.5",
+		"@tsparticles/slim": "^4.0.5",
 		"apexcharts": "^5.12.0",
 		"arctic": "^3.7.0",
 		"cookie": "^1.1.1",
@@ -116,6 +116,6 @@
 		"stripe": "^22.1.1",
 		"three": "^0.184.0",
 		"tippy.js": "^6.3.7",
-		"tsparticles": "^4.0.4"
+		"tsparticles": "^4.0.5"
 	}
 }


### PR DESCRIPTION
This PR resolves an upstream dependency conflict where `@tsparticles/interaction-external-trail@4.0.5` requires an updated version of `@tsparticles/engine`. This was causing build and installation errors. By synchronizing all related `tsparticles` packages to `^4.0.5`, the project installs and builds cleanly without `--force` or `--legacy-peer-deps`.

---
*PR created automatically by Jules for task [4361615068834373835](https://jules.google.com/task/4361615068834373835) started by @nickbrett1*