### PR TITLE
Fix build failures by downgrading svelte-preprocess to 6.0.3

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -82,7 +82,7 @@
 				"shiki": "^4.1.0",
 				"svelte": "^5.53.8",
 				"svelte-awesome-icons": "^3.0.1",
-				"svelte-preprocess": "^6.0.4",
+				"svelte-preprocess": "6.0.3",
 				"tailwindcss": "^4.3.0",
 				"typescript": "^6.0.3",
 				"typescript-eslint": "^8.59.4",
@@ -11152,9 +11152,9 @@
 			}
 		},
 		"node_modules/svelte-preprocess": {
-			"version": "6.0.4",
-			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-6.0.4.tgz",
-			"integrity": "sha512-tevT2/vapolduA23Gp3pFr6qkKakh6TYtXKvWXNaZK67ho9sfV9OSRYb4xsZJsXX7QwtEdpiR63Vbae60rS1qg==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-6.0.3.tgz",
+			"integrity": "sha512-PLG2k05qHdhmRG7zR/dyo5qKvakhm8IJ+hD2eFRQmMLHp7X3eJnjeupUtvuRpbNiF31RjVw45W+abDwHEmP5OA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -11172,7 +11172,7 @@
 				"stylus": ">=0.55",
 				"sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.100 || ^5.0.0",
-				"typescript": "^5.0.0 || ^6.0.0"
+				"typescript": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"@babel/core": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -84,7 +84,7 @@
 		"shiki": "^4.1.0",
 		"svelte": "^5.53.8",
 		"svelte-awesome-icons": "^3.0.1",
-		"svelte-preprocess": "^6.0.4",
+		"svelte-preprocess": "6.0.3",
 		"tailwindcss": "^4.3.0",
 		"typescript": "^6.0.3",
 		"typescript-eslint": "^8.59.4",


### PR DESCRIPTION
Fixes the build failure caused by `svelte-preprocess` auto-updating to 6.0.4. We've pinned the package to `6.0.3` (removing the caret prefix) in `webapp/package.json` and regenerated `package-lock.json`. Tests are passing and the build is stable again.

---
*PR created automatically by Jules for task [372434156544809774](https://jules.google.com/task/372434156544809774) started by @nickbrett1*