### PR TITLE
Update fetch-metadata to v3 in dependabot template

### DIFF
--- a/webapp/src/lib/templates/dependabot-auto-merge.yml.template
+++ b/webapp/src/lib/templates/dependabot-auto-merge.yml.template
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 


### PR DESCRIPTION
This PR updates `dependabot/fetch-metadata` from `v2` to `v3` in the `dependabot-auto-merge.yml.template` file used by the `genproj` capability. This ensures generated projects use the latest major version of the GitHub Action.

---
*PR created automatically by Jules for task [4742503420873019107](https://jules.google.com/task/4742503420873019107) started by @nickbrett1*