### PR TITLE
Fix DevContainer startup failure due to missing host .wrangler directory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 
   "runArgs": ["--sysctl", "net.ipv6.conf.all.disable_ipv6=1"], // Moved from build.runArgs
   "mounts": [
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.wrangler,target=/home/node/.wrangler,type=bind"
+    "source=ftn-wrangler-config,target=/home/node/.wrangler,type=volume"
   ],
   "forwardPorts": [8788, 8976, 36079, 33301, 37677], // Ports for Cloudflare Workers preview and Wrangler dev tools. We use port 8976 as the entry point for OAuth callbacks.
   // Configure tool-specific properties.

--- a/webapp/src/lib/templates/devcontainer-java-json.template
+++ b/webapp/src/lib/templates/devcontainer-java-json.template
@@ -21,7 +21,7 @@
     }
   },
   "mounts": [
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.wrangler,target=/home/vscode/.wrangler,type=bind"
+    "source=wrangler-config,target=/home/vscode/.wrangler,type=volume"
   ],
   "forwardPorts": [8788, 8976, 36079, 33301, 37677],
   "postCreateCommand": ".devcontainer/post-create-setup.sh"

--- a/webapp/src/lib/templates/devcontainer-node-json.template
+++ b/webapp/src/lib/templates/devcontainer-node-json.template
@@ -16,7 +16,7 @@
     "ghcr.io/devcontainers/features/node:1": {}
   },
   "mounts": [
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.wrangler,target=/home/node/.wrangler,type=bind"
+    "source=wrangler-config,target=/home/node/.wrangler,type=volume"
   ],
   "forwardPorts": [8788, 8976, 36079, 33301, 37677],
   "postCreateCommand": ".devcontainer/post-create-setup.sh"

--- a/webapp/src/lib/templates/devcontainer-python-json.template
+++ b/webapp/src/lib/templates/devcontainer-python-json.template
@@ -20,7 +20,7 @@
     }
   },
   "mounts": [
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.wrangler,target=/home/vscode/.wrangler,type=bind"
+    "source=wrangler-config,target=/home/vscode/.wrangler,type=volume"
   ],
   "forwardPorts": [8788, 8976, 36079, 33301, 37677],
   "postCreateCommand": ".devcontainer/post-create-setup.sh"

--- a/webapp/tests/lib/utils/file-generator.test.js
+++ b/webapp/tests/lib/utils/file-generator.test.js
@@ -21,7 +21,7 @@ const nodeJsonTemplateContent = `{
     "ghcr.io/devcontainers/features/node:1": {}
   },
   "mounts": [
-    "source=\${localEnv:HOME}\${localEnv:USERPROFILE}/.wrangler,target=/home/node/.wrangler,type=bind"
+    "source=wrangler-config,target=/home/node/.wrangler,type=volume"
   ],
   "forwardPorts": [8788, 8976, 36079, 33301, 37677],
   "postCreateCommand": ".devcontainer/post-create-setup.sh"


### PR DESCRIPTION
This PR fixes an issue where the DevContainer would fail to start if the host machine did not have a `~/.wrangler` directory. By switching from a host bind mount (`type=bind`) to a Docker named volume (`type=volume`), Docker automatically manages the volume creation, making the DevContainer setup robust and functional out-of-the-box across all environments.

---
*PR created automatically by Jules for task [16949951859626902993](https://jules.google.com/task/16949951859626902993) started by @nickbrett1*