### PR TITLE
Update Antigravity URL

### DIFF
--- a/webapp/src/lib/config/capabilities.js
+++ b/webapp/src/lib/config/capabilities.js
@@ -124,7 +124,7 @@ export const capabilities = [
 			}
 		],
 		links: [
-			{ label: 'Antigravity', url: 'https://goo.gle/gemini-cli-migration' },
+			{ label: 'Antigravity', url: 'https://antigravity.google/product/antigravity-cli' },
 			{ label: 'Cursor', url: 'https://cursor.sh' },
 			{ label: 'Svelte MCP', url: 'https://mcp.svelte.dev/' }
 		]


### PR DESCRIPTION
Replaced the Gemini CLI migration URL with the direct Antigravity CLI product URL (`https://antigravity.google/product/antigravity-cli`) in the Genproj capabilities configuration, as requested.

---
*PR created automatically by Jules for task [9141446670641509146](https://jules.google.com/task/9141446670641509146) started by @nickbrett1*