### PR TITLE
feat: add Cloudflare auth check script (`run-wrangler-dev.sh`)

### DIFF
--- a/webapp/scripts/run-wrangler-dev.sh
+++ b/webapp/scripts/run-wrangler-dev.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# scripts/run-wrangler-dev.sh
+set -e
+
+# Determine the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The project root directory is one level up from the scripts directory
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Change to the project root directory
+cd "$PROJECT_ROOT"
+
+echo "Checking Cloudflare authentication..."
+
+# 1. Check if CLOUDFLARE_API_TOKEN is already in the environment
+if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+  echo "✅ Using CLOUDFLARE_API_TOKEN from environment."
+  exec npx wrangler dev "$@"
+fi
+
+# 2. Check if CLOUDFLARE_API_TOKEN is available via Doppler
+if command -v doppler &> /dev/null && doppler whoami &> /dev/null; then
+  # Check if secret exists in Doppler config
+  if doppler secrets --project webapp --config dev --json 2>/dev/null | grep -q '"CLOUDFLARE_API_TOKEN"'; then
+    echo "✅ Found CLOUDFLARE_API_TOKEN in Doppler. Running wrangler dev via Doppler..."
+    exec doppler run --project webapp --config dev -- npx wrangler dev "$@"
+  fi
+fi
+
+# 3. Check if logged in via Wrangler OAuth session
+WHOAMI_OUT=$(npx wrangler whoami 2>&1 || true)
+
+if echo "$WHOAMI_OUT" | grep -q "You are not authenticated"; then
+  echo "❌ Error: You are not authenticated with Cloudflare."
+  echo "   Wrangler needs to be authenticated to connect to the remote browser rendering API."
+  echo "   Please run the login script first to authenticate:"
+  echo ""
+  echo "   ./scripts/cloud_login.sh"
+  echo ""
+  exit 1
+else
+  echo "✅ Authenticated with Cloudflare."
+  exec npx wrangler dev "$@"
+fi

--- a/webapp/src/lib/templates/scripts-run-wrangler-dev-sh.template
+++ b/webapp/src/lib/templates/scripts-run-wrangler-dev-sh.template
@@ -1,0 +1,44 @@
+#!/bin/bash
+# scripts/run-wrangler-dev.sh
+set -e
+
+# Determine the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# The project root directory is one level up from the scripts directory
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Change to the project root directory
+cd "$PROJECT_ROOT"
+
+echo "Checking Cloudflare authentication..."
+
+# 1. Check if CLOUDFLARE_API_TOKEN is already in the environment
+if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+  echo "✅ Using CLOUDFLARE_API_TOKEN from environment."
+  exec npx wrangler dev "$@"
+fi
+
+# 2. Check if CLOUDFLARE_API_TOKEN is available via Doppler
+if command -v doppler &> /dev/null && doppler whoami &> /dev/null; then
+  # Check if secret exists in Doppler config
+  if doppler secrets --project {{projectName}} --config dev --json 2>/dev/null | grep -q '"CLOUDFLARE_API_TOKEN"'; then
+    echo "✅ Found CLOUDFLARE_API_TOKEN in Doppler. Running wrangler dev via Doppler..."
+    exec doppler run --project {{projectName}} --config dev -- npx wrangler dev "$@"
+  fi
+fi
+
+# 3. Check if logged in via Wrangler OAuth session
+WHOAMI_OUT=$(npx wrangler whoami 2>&1 || true)
+
+if echo "$WHOAMI_OUT" | grep -q "You are not authenticated"; then
+  echo "❌ Error: You are not authenticated with Cloudflare."
+  echo "   Wrangler needs to be authenticated to connect to the remote browser rendering API."
+  echo "   Please run the login script first to authenticate:"
+  echo ""
+  echo "   ./scripts/cloud_login.sh"
+  echo ""
+  exit 1
+else
+  echo "✅ Authenticated with Cloudflare."
+  exec npx wrangler dev "$@"
+fi

--- a/webapp/src/lib/utils/file-generator.js
+++ b/webapp/src/lib/utils/file-generator.js
@@ -21,6 +21,7 @@ import packageJsonTemplate from '../templates/package-json.template?raw';
 import wranglerJsonc from '../templates/wrangler.jsonc.template?raw';
 import wranglerTemplateJsonc from '../templates/wrangler.template.jsonc.template?raw';
 import scriptsCloudLoginSh from '../templates/scripts-cloud-login.sh.template?raw';
+import scriptsRunWranglerDevSh from '../templates/scripts-run-wrangler-dev-sh.template?raw';
 import scriptsSetupWranglerConfigSh from '../templates/scripts-setup-wrangler-config.sh.template?raw';
 import gitignoreTemplate from '../templates/gitignore.template?raw';
 import dependabotConfig from '../templates/dependabot.yml.template?raw';
@@ -203,6 +204,7 @@ const templateImports = {
 	'wrangler-jsonc': wranglerJsonc,
 	'wrangler-template-jsonc': wranglerTemplateJsonc,
 	'scripts-cloud-login-sh': scriptsCloudLoginSh,
+	'scripts-run-wrangler-dev-sh': scriptsRunWranglerDevSh,
 	'scripts-setup-wrangler-config-sh': scriptsSetupWranglerConfigSh,
 	gitignore: gitignoreTemplate,
 	'dependabot-config': dependabotConfig,
@@ -655,6 +657,16 @@ export function generateCloudLoginFiles(templateEngine, context) {
 			googleCloudLogin
 		})
 	});
+
+	if (hasWrangler) {
+		files.push({
+			filePath: 'scripts/run-wrangler-dev.sh',
+			content: templateEngine.generateFile('scripts-run-wrangler-dev-sh', {
+				...context,
+				projectName
+			})
+		});
+	}
 
 	// If SvelteKit is present, we don't generate src/index.js (worker entry point)
 	// because SvelteKit manages its own entry point via the adapter.

--- a/webapp/src/lib/utils/file-generator.js
+++ b/webapp/src/lib/utils/file-generator.js
@@ -617,12 +617,60 @@ python_files = "*.test.py"
 	};
 }
 
+function pushWranglerFiles(templateEngine, context, files, projectName, compatibilityDate) {
+	const hasDoppler = context.capabilities.includes('doppler');
+	const hasSvelteKit = context.capabilities.includes('sveltekit');
+	const mainEntryPoint = hasSvelteKit ? '.svelte-kit/cloudflare/_worker.js' : 'src/index.js';
+
+	files.push({
+		filePath: 'scripts/run-wrangler-dev.sh',
+		content: templateEngine.generateFile('scripts-run-wrangler-dev-sh', {
+			...context,
+			projectName
+		})
+	});
+
+	if (!hasSvelteKit) {
+		files.push({
+			filePath: 'src/index.js',
+			content: templateEngine.generateFile('cloudflare-worker-index-js', context)
+		});
+	}
+
+	if (hasDoppler) {
+		files.push(
+			{
+				filePath: 'wrangler.template.jsonc',
+				content: templateEngine.generateFile('wrangler-template-jsonc', {
+					...context,
+					projectName,
+					compatibilityDate,
+					mainEntryPoint
+				})
+			},
+			{
+				filePath: 'scripts/setup-wrangler-config.sh',
+				content: templateEngine.generateFile('scripts-setup-wrangler-config-sh', context)
+			}
+		);
+	} else {
+		files.push({
+			filePath: 'wrangler.jsonc',
+			content: templateEngine.generateFile('wrangler-jsonc', {
+				...context,
+				projectName,
+				compatibilityDate,
+				mainEntryPoint
+			})
+		});
+	}
+}
+
 export function generateCloudLoginFiles(templateEngine, context) {
 	const files = [];
 	const hasWrangler = context.capabilities.includes('cloudflare-wrangler');
 	const hasDoppler = context.capabilities.includes('doppler');
 	const hasGoogleCloud = context.capabilities.includes('google-cloud');
-	const hasSvelteKit = context.capabilities.includes('sveltekit');
 
 	if (!hasWrangler && !hasDoppler && !hasGoogleCloud) return files;
 
@@ -659,55 +707,7 @@ export function generateCloudLoginFiles(templateEngine, context) {
 	});
 
 	if (hasWrangler) {
-		files.push({
-			filePath: 'scripts/run-wrangler-dev.sh',
-			content: templateEngine.generateFile('scripts-run-wrangler-dev-sh', {
-				...context,
-				projectName
-			})
-		});
-	}
-
-	// If SvelteKit is present, we don't generate src/index.js (worker entry point)
-	// because SvelteKit manages its own entry point via the adapter.
-	// But we still need wrangler configuration.
-	if (hasWrangler) {
-		const mainEntryPoint = hasSvelteKit ? '.svelte-kit/cloudflare/_worker.js' : 'src/index.js';
-
-		if (!hasSvelteKit) {
-			files.push({
-				filePath: 'src/index.js',
-				content: templateEngine.generateFile('cloudflare-worker-index-js', context)
-			});
-		}
-
-		if (hasDoppler) {
-			files.push(
-				{
-					filePath: 'wrangler.template.jsonc',
-					content: templateEngine.generateFile('wrangler-template-jsonc', {
-						...context,
-						projectName: context.projectName || context.name || 'my-project',
-						compatibilityDate,
-						mainEntryPoint
-					})
-				},
-				{
-					filePath: 'scripts/setup-wrangler-config.sh',
-					content: templateEngine.generateFile('scripts-setup-wrangler-config-sh', context)
-				}
-			);
-		} else {
-			files.push({
-				filePath: 'wrangler.jsonc',
-				content: templateEngine.generateFile('wrangler-jsonc', {
-					...context,
-					projectName: context.projectName || context.name || 'my-project',
-					compatibilityDate,
-					mainEntryPoint
-				})
-			});
-		}
+		pushWranglerFiles(templateEngine, context, files, projectName, compatibilityDate);
 	}
 
 	return files;


### PR DESCRIPTION
- Added `webapp/src/lib/templates/scripts-run-wrangler-dev-sh.template` to enforce Cloudflare login checks for Cloudflare capabilities in generated projects
- Made sure it is rendered replacing Handlebars property `{{projectName}}` in Doppler checks
- Included it in `webapp/src/lib/utils/file-generator.js` so it automatically evaluates and is bundled if a `cloudflare-wrangler` capability is detected.
- Cloned the physical bash script directly to `webapp/scripts/run-wrangler-dev.sh` to secure local environment `wrangler dev` tests and `chmod +x`.

---
*PR created automatically by Jules for task [13030688186317689250](https://jules.google.com/task/13030688186317689250) started by @nickbrett1*