### PR TITLE
Fix wrangler templates generating sveltekit assets blindly

### DIFF
--- a/webapp/src/lib/templates/wrangler.jsonc.template
+++ b/webapp/src/lib/templates/wrangler.jsonc.template
@@ -4,11 +4,7 @@
 	"compatibility_date": "{{compatibilityDate}}",
 	"compatibility_flags": [
 		"nodejs_compat"
-	],
-	"assets": {
-		"binding": "ASSETS",
-		"directory": ".svelte-kit/cloudflare"
-	},
+	]{{assetsConfig}},
 	"observability": {
 		"logs": {
 			"enabled": true,

--- a/webapp/src/lib/templates/wrangler.template.jsonc.template
+++ b/webapp/src/lib/templates/wrangler.template.jsonc.template
@@ -4,11 +4,7 @@
 	"compatibility_date": "{{compatibilityDate}}",
 	"compatibility_flags": [
 		"nodejs_compat"
-	],
-	"assets": {
-		"binding": "ASSETS",
-		"directory": ".svelte-kit/cloudflare"
-	},
+	]{{assetsConfig}},
 	"observability": {
 		"logs": {
 			"enabled": true,

--- a/webapp/src/lib/utils/file-generator.js
+++ b/webapp/src/lib/utils/file-generator.js
@@ -664,6 +664,9 @@ function pushWranglerFiles(templateEngine, context, files, projectName, compatib
 	const hasDoppler = context.capabilities.includes('doppler');
 	const hasSvelteKit = context.capabilities.includes('sveltekit');
 	const mainEntryPoint = hasSvelteKit ? '.svelte-kit/cloudflare/_worker.js' : 'src/index.js';
+	const assetsConfig = hasSvelteKit
+		? ',\n\t"assets": {\n\t\t"binding": "ASSETS",\n\t\t"directory": ".svelte-kit/cloudflare"\n\t}'
+		: '';
 
 	files.push({
 		filePath: 'scripts/run-wrangler-dev.sh',
@@ -688,7 +691,8 @@ function pushWranglerFiles(templateEngine, context, files, projectName, compatib
 					...context,
 					projectName,
 					compatibilityDate,
-					mainEntryPoint
+					mainEntryPoint,
+					assetsConfig
 				})
 			},
 			{
@@ -703,7 +707,8 @@ function pushWranglerFiles(templateEngine, context, files, projectName, compatib
 				...context,
 				projectName,
 				compatibilityDate,
-				mainEntryPoint
+				mainEntryPoint,
+				assetsConfig
 			})
 		});
 	}

--- a/webapp/tests/lib/utils/wrangler-generation.test.js
+++ b/webapp/tests/lib/utils/wrangler-generation.test.js
@@ -63,6 +63,7 @@ describe('Cloudflare Wrangler File Generation', () => {
 		// Check that compatibility_date is set to today's date
 		const today = new Date().toISOString().split('T')[0];
 		expect(wranglerJsonc.content).toContain(`"compatibility_date": "${today}"`);
+		expect(wranglerJsonc.content).not.toContain('"assets"');
 
 		const cloudLogin = files.find((f) => f.filePath === 'scripts/cloud_login.sh');
 		expect(cloudLogin).toBeDefined();
@@ -88,6 +89,7 @@ describe('Cloudflare Wrangler File Generation', () => {
 		// Check that compatibility_date is set to today's date
 		const today = new Date().toISOString().split('T')[0];
 		expect(wranglerTemplate.content).toContain(`"compatibility_date": "${today}"`);
+		expect(wranglerTemplate.content).not.toContain('"assets"');
 
 		const setupScript = files.find((f) => f.filePath === 'scripts/setup-wrangler-config.sh');
 		expect(setupScript).toBeDefined();
@@ -121,6 +123,21 @@ describe('Cloudflare Wrangler File Generation', () => {
 		const circleCiConfig = files.find((f) => f.filePath === '.circleci/config.yml');
 		expect(circleCiConfig).toBeDefined();
 		expect(circleCiConfig.content).toContain('./scripts/setup-wrangler-config.sh');
+	});
+
+	it('generates wrangler.jsonc with assets when Cloudflare and SvelteKit are selected', async () => {
+		const context = {
+			name: 'test-project',
+			capabilities: ['cloudflare-wrangler', 'sveltekit'],
+			configuration: {}
+		};
+
+		const files = await generateAllFiles(context);
+
+		const wranglerJsonc = files.find((f) => f.filePath === 'wrangler.jsonc');
+		expect(wranglerJsonc).toBeDefined();
+		expect(wranglerJsonc.content).toContain('"assets"');
+		expect(wranglerJsonc.content).toContain('.svelte-kit/cloudflare');
 	});
 
 	it('includes python ignore patterns in .gitignore when python capability is selected', async () => {


### PR DESCRIPTION
This fixes a bug where `wrangler.template.jsonc` and `wrangler.jsonc` included SvelteKit specific asset bindings regardless of whether the SvelteKit capability was selected.
Replaced the hardcoded `"assets"` block with an `{{assetsConfig}}` template placeholder and dynamically computed it in `pushWranglerFiles` within `file-generator.js`.
Also updated `wrangler-generation.test.js` to ensure the generated configs don't include `"assets"` unless the SvelteKit capability is provided.

---
*PR created automatically by Jules for task [2084596040918038582](https://jules.google.com/task/2084596040918038582) started by @nickbrett1*