### PR TITLE
Fix AgentClient connection parsing in agent-swarm

### DIFF
--- a/webapp/src/routes/projects/agent-swarm/+page.svelte
+++ b/webapp/src/routes/projects/agent-swarm/+page.svelte
@@ -78,12 +78,22 @@
 			addLog(`2. Connecting to WebSocket swarm at ${workerHost}...`, 'step');
 			addLog(`Session ID: ${sessionId}`, 'info');
 
-			const host = `${workerHost}/ws?expiry=${expiry}&signature=${signature}`;
-
 			const client = new AgentClientClass({
 				agent: 'ShopperAgent',
 				name: sessionId,
-				host: host,
+				host: workerHost,
+				query: {
+					expiry,
+					signature
+				},
+				onClose: (event) => {
+					if (!client.identified) {
+						addLog(`❌ WebSocket connection closed unexpectedly. Code: ${event?.code}`, 'system-error');
+					}
+				},
+				onError: (error) => {
+					addLog(`❌ WebSocket error: ${error?.message || 'Unknown error'}`, 'system-error');
+				},
 				onStateUpdate: (state) => {
 					if (state.status) {
 						status = state.status;


### PR DESCRIPTION
Fixes the issue where the Agent Swarm Console hangs silently during connection attempts. `PartySocket` constructs standard URLs from the `host` parameter; passing a URL with a path and query string to `host` generated an invalid URL format. Moving `expiry` and `signature` to the explicit `query` property ensures `PartySocket` formats the URL correctly. Also implements WebSocket error logging.

---
*PR created automatically by Jules for task [2857485239026724876](https://jules.google.com/task/2857485239026724876) started by @nickbrett1*