### PR TITLE
Fix Agent Swarm WebSocket connection hanging and missing errors

### DIFF
--- a/webapp/src/routes/projects/agent-swarm/+page.svelte
+++ b/webapp/src/routes/projects/agent-swarm/+page.svelte
@@ -83,7 +83,7 @@
 				name: sessionId,
 				host: workerHost,
 				query: {
-					expiry,
+					expiry: expiry.toString(),
 					signature
 				},
 				onClose: (event) => {
@@ -103,14 +103,21 @@
 						const newLogs = state.history;
 						// To avoid duplicating logs, reset and add them
 						logs = logs.filter(l => l.type === 'step' || l.type === 'success' || l.type === 'system-error');
-						for (const step of newLogs) {
+						newLogs.forEach(step => {
 							addLog(step, 'agent');
-						}
+						});
 					}
 				}
 			});
 
-			await client.ready;
+			// Add a timeout for the ready signal in case the server fails to send identity
+			let timeoutId;
+			const readyTimeout = new Promise((_, reject) => {
+				timeoutId = setTimeout(() => reject(new Error('Timed out waiting for Agent identity signal. The worker might be unreachable or not returning the correct cf_agent_identity.')), 15000);
+			});
+
+			await Promise.race([client.ready, readyTimeout]);
+			clearTimeout(timeoutId);
 			addLog('✅ WebSocket connection established. Agent ready.', 'success');
 
 			status = 'running';


### PR DESCRIPTION
This pull request addresses the silent UI hang that occurs when connecting to the Cloudflare Agent Swarm.

Key fixes:
1. Replaced the `for...of` array iteration with `.forEach` to prevent Babel/Vite transpilation from generating a broken `_createForOfIteratorHelper` which was crashing iOS Safari entirely.
2. Ensured that the `expiry` query string param passed to the `AgentClientClass` option uses strict string typing to avoid compatibility issues.
3. Added a 15-second connection timeout utilizing `Promise.race()` to gracefully handle and display explicit errors when the WebSocket client fails to receive a readiness signal instead of letting SvelteKit hang silently. The timeout is correctly cleared if the connection establishes within the time limit.

---
*PR created automatically by Jules for task [232280842954886132](https://jules.google.com/task/232280842954886132) started by @nickbrett1*