### PR TITLE
fix: correct agent swarm worker hostname typo

### DIFF
--- a/webapp/src/routes/projects/agent-swarm/+page.svelte
+++ b/webapp/src/routes/projects/agent-swarm/+page.svelte
@@ -9,7 +9,7 @@
 	let status = $state('idle');
 	let errorMsg = $state('');
 	let persona = $state('Shop for tech stickers under $15');
-	let workerHost = $state('agent-swarm.nickbrett1.workers.dev');
+	let workerHost = $state('agent-swarm.nick-brett1.workers.dev');
 	let sessionId = $state('');
 	let isConnecting = $state(false);
 


### PR DESCRIPTION
The `AgentClient` WebSocket connection on the `/projects/agent-swarm` page was hanging because the `workerHost` state was pointing to an invalid Cloudflare worker hostname (`agent-swarm.nickbrett1.workers.dev`). It has been corrected to use the hyphenated username `nick-brett1` to match the expected Cloudflare configuration for the project (e.g. `ftn-preview.nick-brett1.workers.dev`).

This resolves the issue where no requests were registering and the browser timed out waiting for the `cf_agent_identity` signal.

---
*PR created automatically by Jules for task [6637557281508618603](https://jules.google.com/task/6637557281508618603) started by @nickbrett1*