### PR TITLE
Fix Agent Swarm browser time limit display

### DIFF
--- a/webapp/src/routes/projects/agent-swarm/+page.svelte
+++ b/webapp/src/routes/projects/agent-swarm/+page.svelte
@@ -366,7 +366,7 @@
 							{/if}
 							<div class="flex justify-between items-center text-xs border-t border-slate-800/60 pt-3">
 								<span class="text-slate-400">Browser Time Used</span>
-								<span class="text-slate-200 font-mono">{formatSeconds(limits.browser.usedBrowserTimeSeconds)} / {limits.browser.timeLimitSeconds ? formatSeconds(limits.browser.timeLimitSeconds) : 'N/A'}</span>
+								<span class="text-slate-200 font-mono">{formatSeconds(limits.browser.usedBrowserTimeSeconds)} / {limits.browser.browserTimeSecondsLimit ? formatSeconds(limits.browser.browserTimeSecondsLimit) : 'N/A'}</span>
 							</div>
 							{#if limits.ai?.model}
 							<div class="flex justify-between items-center text-xs border-t border-slate-800/60 pt-3">


### PR DESCRIPTION
Updates the Agent Swarm frontend to consume the correct API response property for the browser time limit (`browserTimeSecondsLimit`), rather than looking for a non-existent `timeLimitSeconds` field. This resolves the issue where the browser time limit was rendering as "N/A" on the UI.

---
*PR created automatically by Jules for task [8999309853585047855](https://jules.google.com/task/8999309853585047855) started by @nickbrett1*