### PR TITLE
Update Agent Swarm limits UI to use primary_llm and secondary_llm keys

### DIFF
--- a/webapp/src/routes/projects/agent-swarm/+page.svelte
+++ b/webapp/src/routes/projects/agent-swarm/+page.svelte
@@ -502,23 +502,23 @@
 											: 'N/A'}</span
 									>
 								</div>
-								{#if limits.ai?.model}
+								{#if limits.primary_llm?.model}
 									<div
 										class="flex justify-between items-center text-xs border-t border-slate-800/60 pt-3"
 									>
 										<span class="text-slate-400">Primary AI Model</span>
 										<span class="text-indigo-300 font-mono text-[10px] truncate ml-2"
-											>{limits.ai.model}</span
+											>{limits.primary_llm.model}</span
 										>
 									</div>
 								{/if}
-								{#if limits.gemini?.model}
+								{#if limits.secondary_llm?.model}
 									<div
 										class="flex justify-between items-center text-xs border-t border-slate-800/60 pt-3"
 									>
-										<span class="text-slate-400">Vision Model</span>
+										<span class="text-slate-400">Secondary AI Model</span>
 										<span class="text-indigo-300 font-mono text-[10px] truncate ml-2"
-											>{limits.gemini.model}</span
+											>{limits.secondary_llm.model}</span
 										>
 									</div>
 								{/if}


### PR DESCRIPTION
Updates the UI for the Agent Swarm feature to correctly parse and display the primary and secondary AI models based on recent backend changes to the `/limits` endpoint structure.

Changes include:
*   Refactoring `limits.ai` -> `limits.primary_llm`
*   Refactoring `limits.gemini` -> `limits.secondary_llm`
*   Updating the "Vision Model" display label to "Secondary AI Model"

All tests passed, and local Playwright visual verification confirmed proper rendering.

---
*PR created automatically by Jules for task [3053795707426969295](https://jules.google.com/task/3053795707426969295) started by @nickbrett1*