### PR TITLE
Fix Cloudflare secret deployment errors by using wrangler versions API

### DIFF
--- a/webapp/scripts/sync-doppler-secrets.sh
+++ b/webapp/scripts/sync-doppler-secrets.sh
@@ -68,7 +68,7 @@ echo "🔄 Fetching secrets from Doppler ($DOPPLER_PROJECT/$DOPPLER_CONFIG)..."
 
 # Fetch secrets, compute values, and format for Cloudflare
 cleanup() {
-    rm -f doppler_secrets_common.json doppler_secrets_project.json doppler_secrets.json doppler_secrets_batches.json
+    rm -f doppler_secrets_common.json doppler_secrets_project.json doppler_secrets.json doppler_secrets_batches.json doppler_secrets_batch_temp.json
 }
 trap cleanup EXIT
 
@@ -112,7 +112,8 @@ fi
 echo "🚀 Syncing secrets to Cloudflare ($ENV_DISPLAY_NAME)..."
 SUCCESS=true
 while read -r batch; do
-    echo "$batch" | npx wrangler secret bulk $WRANGLER_ARGS || SUCCESS=false
+    echo "$batch" > doppler_secrets_batch_temp.json
+    npx wrangler versions secret bulk doppler_secrets_batch_temp.json $WRANGLER_ARGS || SUCCESS=false
 done < doppler_secrets_batches.json
 
 if [ "$SUCCESS" = true ]; then

--- a/webapp/src/lib/templates/scripts-sync-doppler-secrets-sh.template
+++ b/webapp/src/lib/templates/scripts-sync-doppler-secrets-sh.template
@@ -68,7 +68,7 @@ echo "🔄 Fetching secrets from Doppler ($DOPPLER_PROJECT/$DOPPLER_CONFIG)..."
 
 # Fetch secrets, compute values, and format for Cloudflare
 cleanup() {
-    rm -f doppler_secrets_common.json doppler_secrets_project.json doppler_secrets.json doppler_secrets_batches.json
+    rm -f doppler_secrets_common.json doppler_secrets_project.json doppler_secrets.json doppler_secrets_batches.json doppler_secrets_batch_temp.json
 }
 trap cleanup EXIT
 
@@ -112,7 +112,8 @@ fi
 echo "🚀 Syncing secrets to Cloudflare ($ENV_DISPLAY_NAME)..."
 SUCCESS=true
 while read -r batch; do
-    echo "$batch" | npx wrangler secret bulk $WRANGLER_ARGS || SUCCESS=false
+    echo "$batch" > doppler_secrets_batch_temp.json
+    npx wrangler versions secret bulk doppler_secrets_batch_temp.json $WRANGLER_ARGS || SUCCESS=false
 done < doppler_secrets_batches.json
 
 if [ "$SUCCESS" = true ]; then


### PR DESCRIPTION
Fixes a deployment issue during CI where the script attempts to modify Cloudflare secrets with `wrangler secret bulk` but fails with `[ERROR] A request to the Cloudflare API ... failed ... Secret edit failed ... [code: 10215]`. By using the newer versions command and saving the secrets to a temporary file instead of passing it via standard input, Wrangler correctly associates the secrets without requiring an active deployment.

---
*PR created automatically by Jules for task [3796268412359742939](https://jules.google.com/task/3796268412359742939) started by @nickbrett1*