### PR TITLE
feat: display browser time until reset in agent swarm ui

### DIFF
--- a/webapp/src/routes/projects/agent-swarm/+page.svelte
+++ b/webapp/src/routes/projects/agent-swarm/+page.svelte
@@ -501,6 +501,16 @@
 											: 'N/A'}</span
 									>
 								</div>
+								{#if limits.browser.timeUntilBrowserTimeReset > 0 && limits.browser.browserTimeSecondsLimit && typeof limits.browser.browserTimeSecondsLimit !== 'string' && limits.browser.usedBrowserTimeSeconds >= limits.browser.browserTimeSecondsLimit}
+									<div
+										class="flex justify-between items-center text-xs border-t border-slate-800/60 pt-3"
+									>
+										<span class="text-slate-400">Time Until Reset</span>
+										<span class="text-rose-400 font-mono"
+											>{formatSeconds(limits.browser.timeUntilBrowserTimeReset)}</span
+										>
+									</div>
+								{/if}
 								{#if limits.primary_llm?.model}
 									<div
 										class="flex justify-between items-center text-xs border-t border-slate-800/60 pt-3"


### PR DESCRIPTION
- Adds a conditional UI block in `webapp/src/routes/projects/agent-swarm/+page.svelte` below "Browser Time Used".
- Evaluates `timeUntilBrowserTimeReset > 0` and ensures `browserTimeSecondsLimit` is numeric and has been exceeded.
- Displays the time until reset in rose color to alert the user.

---
*PR created automatically by Jules for task [17326498430530644577](https://jules.google.com/task/17326498430530644577) started by @nickbrett1*