### PR TITLE
Fix Agent Swarm limits display issue

### DIFF
--- a/webapp/src/routes/projects/agent-swarm/+page.svelte
+++ b/webapp/src/routes/projects/agent-swarm/+page.svelte
@@ -501,13 +501,13 @@
 											: 'N/A'}</span
 									>
 								</div>
-								{#if limits.browser.timeUntilBrowserTimeReset > 0 && limits.browser.browserTimeSecondsLimit && typeof limits.browser.browserTimeSecondsLimit !== 'string' && limits.browser.usedBrowserTimeSeconds >= limits.browser.browserTimeSecondsLimit}
+								{#if limits.browser.browserTimeSecondsLimit && typeof limits.browser.browserTimeSecondsLimit !== 'string' && limits.browser.usedBrowserTimeSeconds >= limits.browser.browserTimeSecondsLimit}
 									<div
 										class="flex justify-between items-center text-xs border-t border-slate-800/60 pt-3"
 									>
 										<span class="text-slate-400">Time Until Reset</span>
 										<span class="text-rose-400 font-mono"
-											>{formatSeconds(limits.browser.timeUntilBrowserTimeReset)}</span
+											>{limits.browser.timeUntilBrowserTimeReset > 0 ? formatSeconds(limits.browser.timeUntilBrowserTimeReset) : 'Unknown'}</span
 										>
 									</div>
 								{/if}


### PR DESCRIPTION
This fixes an issue where the Agent Swarm page failed to indicate when browser time would reset to a user whose usage had exceeded their limit. Previously, the row only displayed if a strictly positive reset time was returned by the API. Now, it always displays the row when limits are reached, showing 'Unknown' if the reset schedule is missing.

---
*PR created automatically by Jules for task [13023572407003628297](https://jules.google.com/task/13023572407003628297) started by @nickbrett1*