### PR TITLE
fix(agent-swarm): disable RPC timeout for long-running runShopping call

### DIFF
--- a/webapp/src/routes/projects/agent-swarm/+page.svelte
+++ b/webapp/src/routes/projects/agent-swarm/+page.svelte
@@ -243,7 +243,7 @@
 			status = 'running';
 			addLog(`3. Invoking RPC runShopping with persona: "${persona}"`, 'step');
 
-			const result = await client.call('runShopping', [persona]);
+			const result = await client.call('runShopping', [persona], { timeout: 0 });
 			status = 'completed';
 			addLog('🎉 Swarm session completed successfully!', 'success');
 			addLog(`Result outcome: ${result}`, 'info');


### PR DESCRIPTION
Disables the default 30-second timeout of the `AgentClient` library for the `runShopping` RPC call by explicitly passing `{ timeout: 0 }`. This prevents the client connection from throwing a timeout error while the backend agent is still actively executing long-running automation tasks.

---
*PR created automatically by Jules for task [10538280040554130013](https://jules.google.com/task/10538280040554130013) started by @nickbrett1*