### PR TITLE
build: fix tippy.js SSR side effects warning

### DIFF
--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -119,7 +119,7 @@ export default defineConfig(({ command, mode }) => {
 			}
 		},
 		ssr: {
-			noExternal: ['three']
+			noExternal: ['three', 'tippy.js']
 		},
 		assetsInclude: ['**/*.glb', '**/*.fbx', '**/*.worker.min.mjs'],
 		build: {


### PR DESCRIPTION
Fixes the build warnings in Wrangler when deploying the SvelteKit app related to `tippy.js` sideEffects config by bundling it during SSR.

---
*PR created automatically by Jules for task [11032933835273107042](https://jules.google.com/task/11032933835273107042) started by @nickbrett1*