### PR TITLE
Fix genproj sonar-project.properties for Python

### DIFF
--- a/webapp/src/lib/utils/capability-template-utils.js
+++ b/webapp/src/lib/utils/capability-template-utils.js
@@ -53,6 +53,9 @@ function getSonarCloudTemplateData(context) {
 		}
 		case 'Python': {
 			languageSettings = 'sonar.python.coverage.reportPaths=coverage.xml';
+			if (context.capabilities?.includes('devcontainer-python')) {
+				languageSettings += '\nsonar.python.version=3.12';
+			}
 
 			break;
 		}

--- a/webapp/tests/lib/utils/capability-template-utils.test.js
+++ b/webapp/tests/lib/utils/capability-template-utils.test.js
@@ -26,7 +26,7 @@ describe('capability-template-utils', () => {
 	});
 
 	describe('getSonarCloudTemplateData', () => {
-		it('should return correct settings for Python', () => {
+		it('should return correct settings for Python without devcontainer', () => {
 			const context = {
 				capabilities: ['sonarcloud'],
 				configuration: {
@@ -35,6 +35,18 @@ describe('capability-template-utils', () => {
 			};
 			const data = getCapabilityTemplateData('sonarcloud', context);
 			expect(data.sonarLanguageSettings).toBe('sonar.python.coverage.reportPaths=coverage.xml');
+		});
+
+		it('should return correct settings for Python with devcontainer', () => {
+			const context = {
+				capabilities: ['sonarcloud', 'devcontainer-python'],
+				configuration: {
+					sonarcloud: { language: 'Python' }
+				}
+			};
+			const data = getCapabilityTemplateData('sonarcloud', context);
+			expect(data.sonarLanguageSettings).toContain('sonar.python.coverage.reportPaths=coverage.xml');
+			expect(data.sonarLanguageSettings).toContain('sonar.python.version=3.12');
 		});
 
 		it('should return correct settings for Java', () => {


### PR DESCRIPTION
Ensure `sonar.python.version` is correctly set in generated `sonar-project.properties` when generating a Python project with SonarQube enabled via genproj.

---
*PR created automatically by Jules for task [7667413143483997752](https://jules.google.com/task/7667413143483997752) started by @nickbrett1*