### PR TITLE
Add test step to generated CircleCI config

### DIFF
--- a/webapp/src/lib/templates/circleci-config.template
+++ b/webapp/src/lib/templates/circleci-config.template
@@ -27,6 +27,7 @@ jobs:
       - run:
           name: Build
           command: npm run build
+{{testSteps}}
 {{lighthouseJobDefinition}}
 {{deployJobDefinition}}
 workflows:

--- a/webapp/src/lib/utils/capability-template-utils.js
+++ b/webapp/src/lib/utils/capability-template-utils.js
@@ -227,6 +227,7 @@ function _applyCloudflareConfig(data, context, contextEnabled, contextName) {
 function getCircleCiTemplateData(context) {
 	const data = {
 		preBuildSteps: '',
+		testSteps: '',
 		lighthouseJobDefinition: '',
 		lighthouseWorkflowJob: '',
 		deployJobDefinition: '',
@@ -247,6 +248,12 @@ function getCircleCiTemplateData(context) {
 	_applyDopplerConfig(data, context);
 	_applyLighthouseConfig(data, context, contextEnabled, contextName);
 	_applyCloudflareConfig(data, context, contextEnabled, contextName);
+
+	if (context.capabilities.includes('devcontainer-node') && context.capabilities.includes('circleci')) {
+		data.testSteps = `      - run:
+          name: Test
+          command: npm run test`;
+	}
 
 	return data;
 }

--- a/webapp/tests/lib/server/circleci-generation.test.js
+++ b/webapp/tests/lib/server/circleci-generation.test.js
@@ -31,4 +31,22 @@ describe('CircleCI Capability Generation', () => {
 		expect(circleCiFile.content).toContain('executor: node/default');
 		expect(circleCiFile.content).toContain('node: circleci/node@5.0.2');
 	});
+
+	it('should generate a test step when devcontainer-node is selected', async () => {
+		const projectConfig = {
+			name: 'test-project',
+			description: 'A test project',
+			configuration: {}
+		};
+
+		const selectedCapabilities = ['circleci', 'devcontainer-node'];
+		const previewData = await generatePreview(projectConfig, selectedCapabilities);
+
+		const circleCiFolder = previewData.files.find(
+			(f) => f.name === '.circleci' && f.type === 'folder'
+		);
+		const circleCiFile = circleCiFolder.children.find((f) => f.name === 'config.yml');
+
+		expect(circleCiFile.content).toContain('npm run test');
+	});
 });


### PR DESCRIPTION
I have updated the `circleci-config.template` to include a `{{testSteps}}` variable after the build step. In `capability-template-utils.js`, I added logic to inject `npm run test` into that variable if both the `devcontainer-node` and `circleci` capabilities are selected. If the condition isn't met, it falls back to an empty string. Finally, I added an integration test to `circleci-generation.test.js` to ensure the logic works as expected. All tests pass successfully.

---
*PR created automatically by Jules for task [8509214610661565549](https://jules.google.com/task/8509214610661565549) started by @nickbrett1*