### PR TITLE
ci: fix sonarcloud scan configuration file path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,8 @@ jobs:
     docker:
       - image: cimg/node:current-browsers
     resource_class: large # Increase to large for more memory and CPU resources
+    environment:
+      SONAR_SCANNER_OPTS: "-Dproject.settings=.sonarcloud.properties"
     steps:
       - checkout:
           method: full


### PR DESCRIPTION
Fixes the SonarCloud scan in CircleCI by explicitly pointing the scanner to `.sonarcloud.properties` using the `SONAR_SCANNER_OPTS` environment variable in the `code_test` job.

---
*PR created automatically by Jules for task [11525069519122682493](https://jules.google.com/task/11525069519122682493) started by @nickbrett1*