### PR TITLE
feat(genproj): Configure SonarCloud settings within generated CircleCI config

### DIFF
--- a/webapp/src/lib/templates/circleci-config.template
+++ b/webapp/src/lib/templates/circleci-config.template
@@ -4,7 +4,7 @@ orbs:
 {{orbs}}
 jobs:
   build:
-    executor: node/default
+    executor: node/default{{jobEnvironment}}
     steps:
       - checkout
       - restore_cache:

--- a/webapp/src/lib/utils/capability-template-utils.js
+++ b/webapp/src/lib/utils/capability-template-utils.js
@@ -224,6 +224,14 @@ function _applyCloudflareConfig(data, context, contextEnabled, contextName) {
 	}
 }
 
+function _applySonarCloudConfig(data, context, contextEnabled, contextName) {
+	if (context.capabilities.includes('sonarcloud')) {
+		data.jobEnvironment = '\n    environment:\n      SONAR_SCANNER_OPTS: "-Dproject.settings=.sonarcloud.properties"';
+		data.orbs += `  sonarcloud: sonarsource/sonarcloud@2.0.0\n`;
+		data.testSteps += `      - sonarcloud/scan${contextEnabled ? `:\n          context: ${contextName}` : ''}\n`;
+	}
+}
+
 function getCircleCiTemplateData(context) {
 	const data = {
 		preBuildSteps: '',
@@ -234,7 +242,8 @@ function getCircleCiTemplateData(context) {
 		deployWorkflowJob: '',
 		orbs: '',
 		additionalWorkflowJobs: '',
-		buildWorkflowJob: '      - build'
+		buildWorkflowJob: '      - build',
+		jobEnvironment: ''
 	};
 
 	const contextConfig = context.configuration?.circleci?.context;
@@ -248,9 +257,10 @@ function getCircleCiTemplateData(context) {
 	_applyDopplerConfig(data, context);
 	_applyLighthouseConfig(data, context, contextEnabled, contextName);
 	_applyCloudflareConfig(data, context, contextEnabled, contextName);
+	_applySonarCloudConfig(data, context, contextEnabled, contextName);
 
 	if (context.capabilities.includes('devcontainer-node') && context.capabilities.includes('circleci')) {
-		data.testSteps = `      - run:
+		data.testSteps += `      - run:
           name: Test
           command: npm run test`;
 	}

--- a/webapp/tests/lib/server/circleci-generation.test.js
+++ b/webapp/tests/lib/server/circleci-generation.test.js
@@ -49,4 +49,60 @@ describe('CircleCI Capability Generation', () => {
 
 		expect(circleCiFile.content).toContain('npm run test');
 	});
+
+	it('should generate sonarcloud configuration when sonarcloud is selected', async () => {
+		const projectConfig = {
+			name: 'test-project',
+			description: 'A test project',
+			configuration: {
+				circleci: {
+					deployTarget: 'none',
+					context: {
+						enabled: true,
+						name: 'common'
+					}
+				}
+			}
+		};
+
+		const selectedCapabilities = ['circleci', 'sonarcloud'];
+
+		const previewData = await generatePreview(projectConfig, selectedCapabilities);
+
+		const circleCiFolder = previewData.files.find(
+			(f) => f.name === '.circleci' && f.type === 'folder'
+		);
+		expect(circleCiFolder).toBeDefined();
+
+		const circleCiFile = circleCiFolder.children.find((f) => f.name === 'config.yml');
+		expect(circleCiFile).toBeDefined();
+
+		expect(circleCiFile.content).toContain('sonarcloud: sonarsource/sonarcloud@2.0.0');
+		expect(circleCiFile.content).toContain('environment:\n      SONAR_SCANNER_OPTS: "-Dproject.settings=.sonarcloud.properties"');
+		expect(circleCiFile.content).toContain('- sonarcloud/scan:\n          context: common');
+	});
+
+	it('should not contain jobEnvironment if sonarcloud is not selected', async () => {
+		const projectConfig = {
+			name: 'test-project',
+			description: 'A test project',
+			configuration: {
+				circleci: {
+					deployTarget: 'none'
+				}
+			}
+		};
+
+		const selectedCapabilities = ['circleci'];
+
+		const previewData = await generatePreview(projectConfig, selectedCapabilities);
+
+		const circleCiFolder = previewData.files.find(
+			(f) => f.name === '.circleci' && f.type === 'folder'
+		);
+		const circleCiFile = circleCiFolder.children.find((f) => f.name === 'config.yml');
+
+		expect(circleCiFile.content).not.toContain('environment:');
+		expect(circleCiFile.content).not.toContain('SONAR_SCANNER_OPTS');
+	});
 });


### PR DESCRIPTION
This change addresses an issue where the `.circleci/config.yml` generated by `genproj` did not correctly point SonarCloud to its settings file when both capabilities were selected.

- Added `{{jobEnvironment}}` variable support to the CircleCI template.
- Implemented `_applySonarCloudConfig` in `capability-template-utils.js` to conditionally inject the `sonarcloud` orb, the `sonarcloud/scan` build step, and `SONAR_SCANNER_OPTS` set to `-Dproject.settings=.sonarcloud.properties`.
- Updated existing logic to append `+=` rather than overwrite `data.testSteps`.
- Added unit test cases to verify the generated outputs for both positive and negative capability combinations.

---
*PR created automatically by Jules for task [6984485233003956437](https://jules.google.com/task/6984485233003956437) started by @nickbrett1*