### PR TITLE
fix(mcp): correct createMcpHandler arguments and route mapping

### DIFF
--- a/webapp/src/routes/api/mcp/+server.js
+++ b/webapp/src/routes/api/mcp/+server.js
@@ -30,8 +30,8 @@ export const POST = async ({ request, platform }) => {
 
 	const server = createMcpServer({ userEmail, platform });
 
-	const handler = createMcpHandler({
-		server
+	const handler = createMcpHandler(server, {
+		route: '/api/mcp'
 	});
 
 	return handler(request);

--- a/webapp/tests/routes/api/mcp/server.test.js
+++ b/webapp/tests/routes/api/mcp/server.test.js
@@ -5,7 +5,9 @@ import { POST } from '../../../../../src/routes/api/mcp/+server.js';
 vi.mock('agents/mcp', () => {
 	const handlerMock = vi.fn((request) => new Response('mock response', { status: 200 }));
 	return {
-		createMcpHandler: vi.fn(() => handlerMock)
+		createMcpHandler: vi.fn((server, options) => {
+			return handlerMock;
+		})
 	};
 });
 


### PR DESCRIPTION
Fixes a 404 Not Found error on the `/api/mcp` endpoint. The issue occurred because `createMcpHandler` from the `agents/mcp` library was called with the wrong arguments (`{ server }` instead of `server, { route: '/api/mcp' }`), causing the internal route matching to fail against the default `'/mcp'` route. Included test updates.

---
*PR created automatically by Jules for task [11269164975306065759](https://jules.google.com/task/11269164975306065759) started by @nickbrett1*