### PR TITLE
chore: make sonar.exclusions match coverage exclusions

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -16,6 +16,6 @@ sonar.sources=webapp/src/routes,webapp/src/lib
 sonar.coverage.exclusions=**/tests/**,**/*.test.js,**/*.spec.js,**/*.test.ts,**/*.spec.ts,**/*test-utils.js,**/*test-helpers.js,**/*-test-utils.js,**/*-test-helpers.js,**/shared-test-*.js,**/test-*.js,webapp/src/routes/projects/ccbilling/budgets/shared-test-helpers.js,webapp/src/lib/server/precompiled-templates.js,webapp/src/lib/templates/**
 
 # Also exclude test utilities from general analysis (not just coverage)
-sonar.exclusions=**/*.test.js,**/*.spec.js,**/*test-utils.js,**/*test-helpers.js,**/shared-test-*.js,webapp/src/lib/server/precompiled-templates.js,webapp/src/lib/templates/**
+sonar.exclusions=**/tests/**,**/*.test.js,**/*.spec.js,**/*.test.ts,**/*.spec.ts,**/*test-utils.js,**/*test-helpers.js,**/*-test-utils.js,**/*-test-helpers.js,**/shared-test-*.js,**/test-*.js,webapp/src/lib/server/precompiled-templates.js,webapp/src/lib/templates/**
 
 

--- a/webapp/src/lib/templates/.sonarcloud.properties.template
+++ b/webapp/src/lib/templates/.sonarcloud.properties.template
@@ -18,4 +18,4 @@ sonar.sources=src
 sonar.coverage.exclusions=**/tests/**,**/*.test.js,**/*.spec.js,**/*.test.ts,**/*.spec.ts,**/*test-utils.js,**/*test-helpers.js,**/*-test-utils.js,**/*-test-helpers.js,**/shared-test-*.js,**/test-*.js
 
 # Also exclude test utilities from general analysis (not just coverage)
-sonar.exclusions=**/*.test.js,**/*.spec.js,**/*test-utils.js,**/*test-helpers.js,**/shared-test-*.js,**/test-*.js
+sonar.exclusions=**/tests/**,**/*.test.js,**/*.spec.js,**/*.test.ts,**/*.spec.ts,**/*test-utils.js,**/*test-helpers.js,**/*-test-utils.js,**/*-test-helpers.js,**/shared-test-*.js,**/test-*.js


### PR DESCRIPTION
Updates `sonar.exclusions` in `.sonarcloud.properties` and the `genproj` `.sonarcloud.properties.template` to exactly match the comprehensive file patterns defined in `sonar.coverage.exclusions`. This change prevents test files, test utilities, and test directories from being subjected to standard SonarCloud static analysis rules.

---
*PR created automatically by Jules for task [6500261234273162076](https://jules.google.com/task/6500261234273162076) started by @nickbrett1*