### PR TITLE
fix(genproj): correct dependabot configuration and file paths for Rust workers

### DIFF
--- a/webapp/src/lib/server/preview-generator.js
+++ b/webapp/src/lib/server/preview-generator.js
@@ -500,7 +500,7 @@ lto = true
 `;
 
 	return {
-		path: 'Cargo.toml',
+		path: 'worker/Cargo.toml',
 		name: 'Cargo.toml',
 		content,
 		size: content.length,
@@ -524,7 +524,7 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
 `;
 
 	return {
-		path: 'src/lib.rs',
+		path: 'worker/src/lib.rs',
 		name: 'lib.rs',
 		content,
 		size: content.length,

--- a/webapp/src/lib/utils/capability-template-utils.js
+++ b/webapp/src/lib/utils/capability-template-utils.js
@@ -481,9 +481,10 @@ function getDependabotTemplateData(context) {
 		context.capabilities.includes('cloudflare-wrangler') &&
 		context.configuration?.['cloudflare-wrangler']?.workerType === 'rust';
 	if (hasRustDevcontainer || hasRustWorker) {
+		const directory = hasRustWorker ? "/worker" : "/";
 		updates.push(`
   - package-ecosystem: "cargo"
-    directory: "/"
+    directory: "${directory}"
     schedule:
       interval: "${interval}"`);
 	}

--- a/webapp/src/lib/utils/file-generator.js
+++ b/webapp/src/lib/utils/file-generator.js
@@ -1042,7 +1042,7 @@ lto = true
 `;
 
 	return {
-		filePath: 'Cargo.toml',
+		filePath: 'worker/Cargo.toml',
 		content
 	};
 }
@@ -1063,7 +1063,7 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
 `;
 
 	return {
-		filePath: 'src/lib.rs',
+		filePath: 'worker/src/lib.rs',
 		content
 	};
 }

--- a/webapp/tests/lib/utils/wrangler-generation.test.js
+++ b/webapp/tests/lib/utils/wrangler-generation.test.js
@@ -185,12 +185,12 @@ describe('Cloudflare Wrangler File Generation', () => {
 
 		const files = await generateAllFiles(context);
 
-		const cargoToml = files.find((f) => f.filePath === 'Cargo.toml');
+		const cargoToml = files.find((f) => f.filePath === 'worker/Cargo.toml');
 		expect(cargoToml).toBeDefined();
 		expect(cargoToml.content).toContain('name = "rust-worker-project"');
 		expect(cargoToml.content).toContain('worker = { version = "0.8.5", features = ["d1"] }');
 
-		const libraryRs = files.find((f) => f.filePath === 'src/lib.rs');
+		const libraryRs = files.find((f) => f.filePath === 'worker/src/lib.rs');
 		expect(libraryRs).toBeDefined();
 		expect(libraryRs.content).toContain('pub async fn main');
 


### PR DESCRIPTION
The generated `dependabot.yml` pointed to the root `/` when a Rust Cloudflare worker was selected, which was inconsistent with where the Rust worker code was expected to be (`/worker`).

Furthermore, it was identified during investigation that the actual generation logic for `Cargo.toml` and `src/lib.rs` for Rust workers incorrectly placed them at the root as well. This PR fixes both the dependabot configuration and the file placement by updating them to use the `/worker` directory correctly. Tests have been updated to assert on these new paths.

---
*PR created automatically by Jules for task [6874472212076773220](https://jules.google.com/task/6874472212076773220) started by @nickbrett1*