### PR TITLE
fix(devcontainer): docsify postinstall exit 127 breaks docker build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,7 +26,11 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g obj2gltf gltf-pipeline gltfjsx source-map @lhci/cli npm-check-updates docsify-cli
+# docsify-cli pulls in docsify@4, whose postinstall (`opencollective-postinstall && npx husky install`)
+# exits with 127 under npm 10 ("husky: not found"), which breaks `docker build`.
+# Install it with --ignore-scripts; the docsify CLI works fine without those scripts.
+RUN npm install -g obj2gltf gltf-pipeline gltfjsx source-map @lhci/cli npm-check-updates \
+    && npm install -g --ignore-scripts docsify-cli
 
 RUN if command -v sentry-cli >/dev/null 2>&1; then \
         echo "sentry-cli is already installed. Updating..."; \


### PR DESCRIPTION
## Problem

The devcontainer build fails with:

```
ERROR: failed to solve: process "/bin/sh -c apt-get update ... && npm install -g obj2gltf ... docsify-cli ..." did not complete successfully: exit code: 127
```

## Root cause (reproduced)

The failing step is `npm install -g ... docsify-cli`. `docsify-cli` depends on `docsify@4`, whose `postinstall` script is:

```
opencollective-postinstall && npx husky install
```

With the base image's toolchain (node 22.23.2 / npm 10.9.8 — verified by running the exact same install in a Debian bookworm arm64 environment with those versions), `npx husky install` fails with `sh: 1: husky: not found` → exit **127**, which aborts the whole `&&` chain and fails `docker build`.

Note: PR #3954 (already merged) split the giant RUN and added `wget`/`unzip`/`sudo` to apt, but the npm step still contained `docsify-cli`, so the build still fails with 127.

## Fix (verified)

Install `docsify-cli` separately with `--ignore-scripts` so docsify's broken postinstall is skipped. The other global packages keep their normal install scripts (e.g. `gl`'s prebuild for obj2gltf).

```dockerfile
RUN npm install -g obj2gltf gltf-pipeline gltfjsx source-map @lhci/cli npm-check-updates \
    && npm install -g --ignore-scripts docsify-cli
```

Verified with node 22.23.2 + npm 10.9.8 (the exact versions in the base image):
- both npm steps exit 0
- all CLIs work: `obj2gltf 3.2.0`, `gltf-pipeline 4.3.1`, `gltfjsx 6.5.3`, `lhci 0.15.1`, `ncu 23.0.1`, `docsify 5.0.0`