### PR TITLE
fix(devcontainer): split node-user tool installs to isolate exit-1 failure

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -fsSL -o /tmp/tmux.tar.gz "https://github.com/tmux/tmux/releases/downlo
     && make install \
     && rm -rf /tmp/tmux.tar.gz /tmp/tmux-src
 
-# Install Oh My Zsh plugins and themes, specify-cli, and Cursor CLI as node user
+# Oh My Zsh plugins and themes as node user
 USER node
 ENV USER_HOME_DIR=/home/node
 RUN mkdir -p "$USER_HOME_DIR/.oh-my-zsh/custom/themes" "$USER_HOME_DIR/.oh-my-zsh/custom/plugins" \
@@ -67,12 +67,22 @@ RUN mkdir -p "$USER_HOME_DIR/.oh-my-zsh/custom/themes" "$USER_HOME_DIR/.oh-my-zs
     && rm -rf "$USER_HOME_DIR/.oh-my-zsh/custom/plugins/zsh-autosuggestions" \
     && git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "$USER_HOME_DIR/.oh-my-zsh/custom/themes/powerlevel10k" \
     && git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting.git "$USER_HOME_DIR/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting" \
-    && git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions.git "$USER_HOME_DIR/.oh-my-zsh/custom/plugins/zsh-autosuggestions" \
-    && uv tool install --python 3.11 git+https://github.com/github/spec-kit.git \
-    && curl https://cursor.com/install -fsS | bash \
-    && curl -fsSL https://antigravity.google/cli/install.sh | bash \
-    && curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash \
-    && mkdir -p "$HOME/.wrangler"
+    && git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions.git "$USER_HOME_DIR/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
+
+# specify-cli (spec-kit) via uv
+RUN uv tool install --python 3.11 git+https://github.com/github/spec-kit.git
+
+# Cursor agent CLI
+RUN curl https://cursor.com/install -fsS | bash
+
+# Antigravity CLI
+RUN curl -fsSL https://antigravity.google/cli/install.sh | bash
+
+# goose CLI
+RUN curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+
+# Wrangler config volume mount point
+RUN mkdir -p "$HOME/.wrangler"
 
 
 # Add uv tools to PATH for node user


### PR DESCRIPTION
## Problem

The build now gets past the `npm install`/127 issue and fails later, in the `USER node` step:

```
RUN mkdir ... && git clone powerlevel10k ... && uv tool install --python 3.11 git+...spec-kit.git \
    && curl https://cursor.com/install -fsS | bash \
    && curl -fsSL https://antigravity.google/cli/install.sh | bash \
    && curl -fsSL .../download_cli.sh | CONFIGURE=false bash \
    && mkdir -p "$HOME/.wrangler"
... did not complete successfully: exit code: 1
```

The combined `&&` chain means the error summary can't tell us which subcommand failed.

## Change

Split that one big `RUN` into individual `RUN` steps (one per tool). This:
1. Makes the failing step obvious from the build error (each `RUN` is now a single installer).
2. Improves layer caching (a failed tool only re-runs that tool after fixes).

## Verified independently (Debian bookworm arm64, non-root — same as the container)

- git clones of powerlevel10k / zsh-syntax-highlighting / zsh-autosuggestions: OK
- `uv tool install --python 3.11 git+https://github.com/github/spec-kit.git`: OK (installs `specify`)
- `curl https://cursor.com/install -fsS | bash`: OK
- `curl -fsSL https://antigravity.google/cli/install.sh | bash`: OK (installs `agy`)
- `curl -fsSL .../download_cli.sh | CONFIGURE=false bash`: OK

If the next build still fails, the error will name the exact tool, and we can fix that specific one.