### PR TITLE
fix(devcontainer): WORKDIR /home/node so goose installer can write downloads

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -61,6 +61,11 @@ RUN curl -fsSL -o /tmp/tmux.tar.gz "https://github.com/tmux/tmux/releases/downlo
 # Oh My Zsh plugins and themes as node user
 USER node
 ENV USER_HOME_DIR=/home/node
+# The goose installer downloads the release tarball to the current working
+# directory (curl --output <name>), which is '/' by default and not writable by
+# the non-root 'node' user -> "Failed to download" (curl exit 23). Run node-user
+# steps from a writable home directory.
+WORKDIR /home/node
 RUN mkdir -p "$USER_HOME_DIR/.oh-my-zsh/custom/themes" "$USER_HOME_DIR/.oh-my-zsh/custom/plugins" \
     && rm -rf "$USER_HOME_DIR/.oh-my-zsh/custom/themes/powerlevel10k" \
     && rm -rf "$USER_HOME_DIR/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting" \


### PR DESCRIPTION
## The actual failing step (finally pinpointed!)

With the RUNs split (PR #3956), the build now fails at exactly one step:

```
[12/16] RUN curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash:
...
0.363 PWD: /
0.363 Detected OS: linux with ARCH aarch64
0.363 Downloading stable release: goose-aarch64-unknown-linux-gnu.tar.bz2...
1.194 Error: Failed to download from fallback url .../v1.45.0/goose-aarch64-unknown-linux-gnu.tar.bz2 using latest tag v1.45.0
```

## Root cause

The goose installer downloads the release tarball **to the current working directory**:

```sh
curl -sLf "$DOWNLOAD_URL" --output "$FILE"     # relative path → CWD
```

The node-user `RUN` steps execute with the default Docker `WORKDIR` of `/`. The non-root `node` user can't write to `/`, so `curl` fails with **exit 23 (write error)** on both the primary and fallback URLs — not a network problem at all. The asset exists and downloads fine (verified: HTTP 200 for `goose-aarch64-unknown-linux-gnu.tar.bz2` at v1.45.0).

Reproduced locally as a non-root user:

```
$ cd / && curl -sLf --output x https://github.com/aaif-goose/goose/releases/download/v1.45.0/goose-aarch64-unknown-linux-gnu.tar.bz2
exit=23    (couldn't open output file /x: Permission denied)
```

## Fix

```dockerfile
USER node
ENV USER_HOME_DIR=/home/node
WORKDIR /home/node      # ← writable cwd for the non-root node user
```

This makes the goose installer's relative `--output` write to `/home/node` instead of `/`, and is generally the right cwd for the node-user tool installs (cursor/antigravity/uv already use absolute `$HOME` paths).