### PR TITLE
fix(genproj): goose/cloud_login.sh fail with guidance when Doppler is unauthenticated

### DIFF
--- a/webapp/src/lib/templates/scripts-cloud-login.sh.template
+++ b/webapp/src/lib/templates/scripts-cloud-login.sh.template
@@ -9,9 +9,12 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 # Change to the project root directory so that relative paths work correctly
 cd "$PROJECT_ROOT"
 
-{{tailscaleLogin}}
-
+# Doppler login first: it is the critical path for goose (and the wrangler /
+# google-cloud sections below depend on it). Tailscale is optional SSH access
+# and its interactive 'tailscale up' prompt must not block the rest.
 {{dopplerLogin}}
+
+{{tailscaleLogin}}
 
 {{wranglerLogin}}
 

--- a/webapp/src/lib/utils/file-generator.js
+++ b/webapp/src/lib/utils/file-generator.js
@@ -117,6 +117,20 @@ export const GOOSE_ALIAS = `# A robust function to run goose with Doppler, ensur
 # Overrides the bare \`goose\` binary (which can't work standalone: it needs Doppler secrets).
 goose() {
   echo "Starting goose with Doppler (common + goose)..."
+  # Doppler auth pre-flight: fail with actionable guidance instead of the cryptic
+  # "Doppler Error: you must provide a token" that 'doppler run' emits when the
+  # container has no Doppler auth (fresh devcontainer / codespace).
+  if ! command -v doppler &> /dev/null; then
+    echo "❌ Doppler CLI not found - goose needs Doppler secrets to start."
+    echo "   Finish the devcontainer post-create setup (it installs the CLI), then try again."
+    return 127
+  fi
+  if ! doppler whoami &> /dev/null 2>&1; then
+    echo "❌ Not authenticated with Doppler - goose needs Doppler secrets to start."
+    echo "   Run: bash scripts/cloud_login.sh   (interactive browser login)"
+    echo "   Or set a service token:  export DOPPLER_TOKEN=dp.st.<token>"
+    return 1
+  fi
   # Load common secrets first, then layer goose project secrets on top.
   # Uses 'prd' config for the goose project to pick up LITELLM endpoint env vars.
   # --forward-signals ensures SIGINT/SIGTERM are correctly passed through to goose.
@@ -248,16 +262,29 @@ fi
 export const DOPPLER_LOGIN_SCRIPT = `
 # Doppler login/setup
 if command -v doppler &> /dev/null; then
-  if doppler whoami &> /dev/null; then
-    echo "Already logged in to Doppler."
+  if doppler whoami &> /dev/null 2>&1; then
+    echo "✅ Already logged in to Doppler."
   else
-    echo "INFO: Logging into Doppler..."
-    doppler login --no-check-version --no-timeout --yes
-    echo "INFO: Setting up Doppler..."
-    doppler setup --no-interactive --project {{projectName}} --config dev
+    echo "INFO: Logging into Doppler (browser flow)..."
+    echo "      If a browser does not open, copy the URL and auth code printed above into"
+    echo "      your browser to complete the login, then return here."
+    if doppler login --no-check-version --yes; then
+      echo "✅ Doppler login successful."
+      if doppler setup --no-interactive --project {{projectName}} --config dev; then
+        echo "✅ Doppler project {{projectName}}/dev configured."
+      else
+        echo "WARN: doppler setup failed for {{projectName}}/dev - the project may not"
+        echo "      exist yet. Create it at https://dashboard.doppler.com, then run:"
+        echo "      doppler setup --no-interactive --project {{projectName}} --config dev"
+      fi
+    else
+      echo "❌ Doppler login did not complete. Re-run this script (or 'doppler login'),"
+      echo "   or authenticate with a service token:  export DOPPLER_TOKEN=dp.st.<token>"
+    fi
   fi
 else
-  echo "Doppler CLI not found. Skipping Doppler login."
+  echo "⚠️  Doppler CLI not found. Skipping Doppler login - run 'goose' after the"
+  echo "    devcontainer post-create setup finishes, or install the CLI manually."
 fi`;
 
 export const WRANGLER_LOGIN_SCRIPT = String.raw`

--- a/webapp/tests/lib/utils/devcontainer-generation.test.js
+++ b/webapp/tests/lib/utils/devcontainer-generation.test.js
@@ -201,6 +201,14 @@ describe('DevContainer Generation Tests', () => {
 		expect(zshrc).toContain(
 			'# If a Doppler wrapper already defined goose() above, it already routes through'
 		);
+		// Doppler auth pre-flight: a fresh devcontainer/codespace has no Doppler
+		// auth, and 'doppler run' would otherwise die with the cryptic "Doppler
+		// Error: you must provide a token". The wrapper must fail with guidance
+		// instead of a bare doppler error.
+		expect(zshrc).toContain('if ! doppler whoami &> /dev/null 2>&1; then');
+		expect(zshrc).toContain('bash scripts/cloud_login.sh');
+		expect(zshrc).toContain('export DOPPLER_TOKEN=dp.st.<token>');
+		expect(zshrc).toContain('Not authenticated with Doppler');
 	});
 
 	it('joins an existing tmux session for terminals starting outside the workspace', async () => {

--- a/webapp/tests/lib/utils/wrangler-generation.test.js
+++ b/webapp/tests/lib/utils/wrangler-generation.test.js
@@ -83,6 +83,25 @@ describe('Cloudflare Wrangler File Generation', () => {
 		expect(wranglerTemplate).toBeUndefined();
 	});
 
+	it('runs the doppler block before the tailscale block in cloud_login.sh', async () => {
+		const context = {
+			name: 'test-project',
+			capabilities: ['doppler', 'devcontainer-node'],
+			configuration: {}
+		};
+
+		const files = await generateAllFiles(context);
+		const cloudLogin = files.find((f) => f.filePath === 'scripts/cloud_login.sh');
+		expect(cloudLogin).toBeDefined();
+		// Doppler auth is the critical path for goose; an interactive 'tailscale
+		// up' prompt must not starve it in a fresh devcontainer.
+		expect(cloudLogin.content.indexOf('# Doppler login/setup')).toBeGreaterThan(-1);
+		expect(cloudLogin.content.indexOf('# Tailscale login')).toBeGreaterThan(-1);
+		expect(cloudLogin.content.indexOf('# Doppler login/setup')).toBeLessThan(
+			cloudLogin.content.indexOf('# Tailscale login')
+		);
+	});
+
 	it('generates wrangler.template.jsonc and setup scripts when Cloudflare and Doppler are selected', async () => {
 		const context = {
 			name: 'test-project',
@@ -111,6 +130,11 @@ describe('Cloudflare Wrangler File Generation', () => {
 		expect(cloudLogin.content).toContain('doppler login');
 		expect(cloudLogin.content).toContain('doppler setup --no-interactive --project test-project');
 		expect(cloudLogin.content).toContain('./scripts/setup-wrangler-config.sh');
+		// Login is verified afterwards and failure prints actionable guidance
+		// (instead of silently finishing without Doppler auth).
+		expect(cloudLogin.content).toContain('Doppler login successful');
+		expect(cloudLogin.content).toContain('export DOPPLER_TOKEN=dp.st.<token>');
+		expect(cloudLogin.content).toContain('Already logged in to Doppler');
 
 		const wranglerJsonc = files.find((f) => f.filePath === 'wrangler.jsonc');
 		expect(wranglerJsonc).toBeUndefined(); // Should not generate wrangler.jsonc directly


### PR DESCRIPTION
## Problem

Generated projects (e.g. **parquet-peek**) break on first launch: in a fresh devcontainer/codespace there is no Doppler auth (the host `~/.doppler` bind-mount is empty), so the generated `goose()` wrapper dies with the cryptic:

```
Doppler Error: you must provide a token
```

and `scripts/cloud_login.sh` gives no actionable path — its `doppler login` silently failed/waited, its `doppler setup` could abort the whole script (project doesn't exist yet), and the browser-flow login ran *after* the interactive tailscale block.

## Fix

1. **`GOOSE_ALIAS`** — pre-flight `doppler whoami` check in the generated `goose()`:
   - missing CLI → clear message (finish post-create setup)
   - missing auth → `bash scripts/cloud_login.sh` / `export DOPPLER_TOKEN=dp.st.<token>`
   - no more bare `Doppler Error: you must provide a token`
2. **`DOPPLER_LOGIN_SCRIPT`** — `doppler login` now:
   - verifies the login succeeded (✅ / ❌ messages)
   - warns instead of aborting when `doppler setup` fails (project not created yet)
   - prints explicit next steps if the browser flow is cancelled
3. **`scripts-cloud-login.sh.template`** — the Doppler block now runs **before** the Tailscale block, so an interactive `tailscale up` prompt can't starve the critical-path login.

## Tests

- devcontainer-generation: wrapper pre-flight assertions
- wrangler-generation: verified-login + doppler-before-tailscale ordering
- Full suite green: **1813 passed / 24 skipped**; prettier + eslint clean (0 errors)

## Follow-up

Deploy to fintechnick.com so newly generated projects get this. Existing projects like parquet-peek can be regenerated, or the two scripts updated manually.