### PR TITLE
fix(genproj): Homepage href/widget use the published host port, not the container port

### DIFF
--- a/webapp/src/lib/config/capabilities.js
+++ b/webapp/src/lib/config/capabilities.js
@@ -668,7 +668,7 @@ export const capabilities = [
 				publishPort: {
 					type: 'string',
 					description:
-						'Compose port binding, e.g. "3000:3000" or "127.0.0.1:3000:3000" for a private (Tailscale-only) service.',
+						'Compose port binding, e.g. "3000:3000" or "127.0.0.1:3000:3000" for a private (Tailscale-only) service. The left-hand side is the published HOST port — Homepage href/widget URLs use it, so "127.0.0.1:3002:3000" yields http://<hostname>:3002/.',
 					default: '3000:3000'
 				},
 				baseImage: {

--- a/webapp/src/lib/templates/deploy-readme.template
+++ b/webapp/src/lib/templates/deploy-readme.template
@@ -82,6 +82,9 @@ enable the `homepage` Docker provider) to show a health widget for the service.
 - Only one LAN-protocol client may bind the fixed ports per host IP.
 - For private services (Tailscale-only), set `publishPort` to
   `127.0.0.1:<port>:<port>` so the port is not exposed on the LAN.
+- Homepage href/widget URLs use the **published host port** (the left-hand
+  side of `publishPort`), so `127.0.0.1:3002:3000` produces
+  `http://<hostname>:3002/` — never the container port.
 
 ## 7. Data mounts
 

--- a/webapp/src/lib/templates/homepage-services.template
+++ b/webapp/src/lib/templates/homepage-services.template
@@ -3,7 +3,8 @@
 # Append to your Homepage services.yaml (under the "Services" group) and enable
 # the homepage Docker provider. The href defaults to localhost (the browser
 # resolves it from your device); override `hostname` in the genproj
-# configuration to point at your NAS hostname/IP.
+# configuration to point at your NAS hostname/IP. The URL uses the PUBLISHED
+# HOST port (left-hand side of publishPort), not the container port.
 #
 # The widget block is only emitted when a health mechanism is declared
 # (docker-container `healthcheck` config); without one there is no endpoint to
@@ -11,6 +12,6 @@
 
 - {{projectName}}:
     icon: sh-docker
-    href: http://{{hostname}}:{{exposePort}}/
+    href: http://{{hostname}}:{{hostPort}}/
     description: {{projectName}} container
 {{homepageWidget}}

--- a/webapp/src/lib/utils/capability-template-utils.js
+++ b/webapp/src/lib/utils/capability-template-utils.js
@@ -565,6 +565,33 @@ function getDockerRegistryPrefix() {
 }
 
 /**
+ * Derives the host port from a compose publishPort binding.
+ *
+ * Format: `[hostIp:]hostPort:containerPort[/proto]` — e.g. `"3000:3000"`,
+ * `"127.0.0.1:3002:3000"`, `"0.0.0.0:8080:80/tcp"`. The host port is the
+ * left-hand side of the mapping: the port actually bound on the host, which
+ * is what browser-facing URLs (Homepage href/widget) must use. When the
+ * container port is also the host port this is invisible; when they differ
+ * (loopback-bound services, ports allocated by nas-port-mcp) using the
+ * container port produces a URL nothing listens on.
+ *
+ * Falls back to `exposePort` when publishPort is unset or unparseable, so
+ * the default (`3000:3000` -> hostPort 3000) is unchanged. Indexing from the
+ * end also tolerates bracketed IPv6 host IPs (`[::1]:3002:3000`).
+ *
+ * @param {string|undefined} publishPort - Compose port binding from config
+ * @param {number|string} exposePort - Container port (fallback host port)
+ * @returns {number|string} The published host port
+ */
+function getHostPort(publishPort, exposePort) {
+	if (typeof publishPort !== 'string' || !publishPort.includes(':')) return exposePort;
+	const parts = publishPort.split(':');
+	if (parts.length < 2) return exposePort;
+	const hostPort = parts[parts.length - 2];
+	return /^\d+$/.test(hostPort) ? hostPort : exposePort;
+}
+
+/**
  * Builds template data for the docker-container deployment capability.
  * Provides language-aware Dockerfile fragments, compose fragments, and
  * registry metadata for generated deploy artifacts.
@@ -704,7 +731,13 @@ function getDockerContainerTemplateData(context) {
 	// 3.4: publishPort controls the compose port binding. Default is
 	// "<exposePort>:<exposePort>" (all interfaces). Bind to 127.0.0.1 (or a
 	// specific interface) to keep the service private (e.g. Tailscale-only).
+	// hostPort is the left-hand side of the binding — the port actually bound
+	// on the host — and is what browser-facing URLs (Homepage href/widget)
+	// must use: when publishPort maps a different host port than the container
+	// port (e.g. "127.0.0.1:3002:3000"), the container port is wrong for URLs
+	// (memo: genproj-homepage-port-wart).
 	const publishPort = config.publishPort || `${exposePort}:${exposePort}`;
+	const hostPort = getHostPort(publishPort, exposePort);
 	const portsConfig = networkMode === 'host' ? '' : `    ports:\n      - "${publishPort}"`;
 
 	// 3.3: dataMounts config -> compose volumes (read-only by default).
@@ -746,19 +779,23 @@ function getDockerContainerTemplateData(context) {
 		labels.push(
 			'      - "homepage.group=Services"',
 			`      - "homepage.name=${projectName}"`,
-			`      - "homepage.href=http://${hostname}:${exposePort}/"`
+			`      - "homepage.href=http://${hostname}:${hostPort}/"`
 		);
 		// Widget only when a real health endpoint exists (memo §2.8).
 		if (healthcheckPath) {
 			labels.push(
 				'      - "homepage.widget.type=customapi"',
-				`      - "homepage.widget.url=http://localhost:${exposePort}${healthcheckPath}"`
+				`      - "homepage.widget.url=http://localhost:${hostPort}${healthcheckPath}"`
 			);
 		}
 	}
 
+	// Homepage's Docker provider queries the daemon, so the widget URL
+	// legitimately uses localhost (even for a loopback-bound service) — but it
+	// must still point at the published HOST port, never the container port
+	// (memo: genproj-homepage-port-wart).
 	const homepageWidget = healthcheckPath
-		? `    widget:\n      type: customapi\n      url: http://${hostname}:${exposePort}${healthcheckPath}`
+		? `    widget:\n      type: customapi\n      url: http://localhost:${hostPort}${healthcheckPath}`
 		: '';
 
 	return {
@@ -772,6 +809,7 @@ function getDockerContainerTemplateData(context) {
 		dockerHealthcheck,
 		dockerRunCommand,
 		exposePort: String(exposePort),
+		hostPort: String(hostPort),
 		networkMode,
 		networkModeLine,
 		portsConfig,

--- a/webapp/tests/docker-container-capability.test.js
+++ b/webapp/tests/docker-container-capability.test.js
@@ -190,6 +190,43 @@ describe('docker-container template data', () => {
 		expect(data.volumesConfig).not.toContain('/volume1/writable:/writable:ro');
 	});
 
+	it('derives the Homepage host port from the left-hand side of publishPort (genproj-homepage-port-wart)', () => {
+		const data = getCapabilityTemplateData('docker-container', {
+			capabilities: ['docker-container'],
+			configuration: {
+				'docker-container': {
+					publishPort: '127.0.0.1:3002:3000',
+					hostname: 'nas',
+					healthcheck: 'http:/health'
+				}
+			},
+			projectName: 'parquet-peek'
+		});
+		// hostPort = left-hand side of the mapping, never the container port.
+		expect(data.hostPort).toBe('3002');
+		expect(data.exposePort).toBe('3000');
+		// Compose labels: href uses hostname + hostPort; widget uses
+		// localhost + hostPort (Homepage queries the daemon).
+		expect(data.composeLabels).toContain('homepage.href=http://nas:3002/');
+		expect(data.composeLabels).toContain('homepage.widget.url=http://localhost:3002/health');
+		// Snippet agrees with the labels (single source of truth for the port).
+		expect(data.homepageWidget).toContain('url: http://localhost:3002/health');
+		// The compose port binding itself is untouched.
+		expect(data.portsConfig).toContain('127.0.0.1:3002:3000');
+	});
+
+	it('keeps default Homepage URLs when publishPort is unset (no regression)', () => {
+		const data = getCapabilityTemplateData('docker-container', {
+			capabilities: ['docker-container', 'devcontainer-node'],
+			configuration: {},
+			projectName: 'demo-app'
+		});
+		expect(data.hostPort).toBe('3000');
+		expect(data.composeLabels).toContain('homepage.href=http://localhost:3000/');
+		expect(data.composeLabels).toContain('homepage.widget.url=http://localhost:3000/health');
+		expect(data.homepageWidget).toContain('url: http://localhost:3000/health');
+	});
+
 	it('uses a python base image for python projects', () => {
 		const data = getCapabilityTemplateData('docker-container', {
 			capabilities: ['docker-container', 'devcontainer-python'],

--- a/webapp/tests/lib/utils/file-generator-python.test.js
+++ b/webapp/tests/lib/utils/file-generator-python.test.js
@@ -407,6 +407,56 @@ describe('Node regression (memo §6)', () => {
 	});
 });
 
+describe('Homepage URLs use the published host port (genproj-homepage-port-wart)', () => {
+	it('emits href/widget with the HOST port when publishPort maps a different host port', async () => {
+		const context = {
+			projectName: 'parquet-peek',
+			description: 'Peek at Databento parquet files from the phone.',
+			capabilities: ['sveltekit', 'devcontainer-node', 'docker-container', 'circleci'],
+			configuration: {
+				'docker-container': {
+					publishPort: '127.0.0.1:3002:3000',
+					hostname: 'nas',
+					healthcheck: 'http:/health'
+				}
+			},
+			registryNamespace: 'nickbrett1'
+		};
+		const files = await generateAllFiles(context);
+
+		const compose = files.find((f) => f.filePath === 'docker-compose.yml');
+		// href: browser-facing -> configured hostname + host port 3002.
+		expect(compose.content).toContain('homepage.href=http://nas:3002/');
+		expect(compose.content).not.toContain('homepage.href=http://nas:3000/');
+		// widget: Homepage queries the daemon -> localhost, but still host port 3002.
+		expect(compose.content).toContain('homepage.widget.url=http://localhost:3002/health');
+		expect(compose.content).not.toContain('homepage.widget.url=http://localhost:3000/health');
+
+		// Snippet agrees with the compose labels (single source of truth).
+		const homepage = files.find((f) => f.filePath === 'deploy/homepage-services.yaml');
+		expect(homepage.content).toContain('href: http://nas:3002/');
+		expect(homepage.content).toContain('url: http://localhost:3002/health');
+		expect(homepage.content).not.toContain(':3000/');
+	});
+
+	it('keeps default ports in compose labels and snippet when publishPort is unset', async () => {
+		const context = {
+			projectName: 'demo-app',
+			capabilities: ['sveltekit', 'devcontainer-node', 'docker-container'],
+			configuration: {},
+			registryNamespace: 'nickbrett1'
+		};
+		const files = await generateAllFiles(context);
+
+		const compose = files.find((f) => f.filePath === 'docker-compose.yml');
+		expect(compose.content).toContain('homepage.href=http://localhost:3000/');
+		expect(compose.content).toContain('homepage.widget.url=http://localhost:3000/health');
+		const homepage = files.find((f) => f.filePath === 'deploy/homepage-services.yaml');
+		expect(homepage.content).toContain('href: http://localhost:3000/');
+		expect(homepage.content).toContain('url: http://localhost:3000/health');
+	});
+});
+
 describe('docker-container template data (config plumbing)', () => {
 	it('exposes envVars/aptPackages/healthcheck/pythonDependencies fragments to templates', () => {
 		const data = getCapabilityTemplateData('docker-container', {


### PR DESCRIPTION
Fixes the wart from memo `memos/genproj-homepage-port-wart` (found in the parquet-peek e2e verification, audit memo §12).

## Problem

When `publishPort` binds a **different host port than the container port** (e.g. `127.0.0.1:3002:3000` — loopback-bound services or ports allocated by nas-port-mcp), the generated Homepage URLs (compose labels + `deploy/homepage-services.yaml`) used the **container port** (3000), producing a URL nothing listens on. Invisible when the ports match (`3000:3000`); wrong the moment they differ.

## Fix

- **`getHostPort()`** in `capability-template-utils.js`: parse `publishPort` (`[hostIp:]hostPort:containerPort[/proto]`) and derive the **published host port** (left-hand side). Falls back to `exposePort` when unset/unparseable → default `3000:3000` → hostPort 3000, zero change for default users. Indexing from the end also tolerates bracketed IPv6 host IPs.
- **Compose labels**: `homepage.href=http://<hostname>:<hostPort>/`, `homepage.widget.url=http://localhost:<hostPort><path>`. Widget keeps `localhost` (Homepage's Docker provider queries the daemon) — only the port was wrong.
- **`deploy/homepage-services.yaml` snippet**: same `hostPort`; widget URL now uses `localhost` consistently with the labels (single source of truth for the port).
- Schema description (`publishPort`) + `deploy/README.md` document the host-port semantics.

## Acceptance criteria (from memo)

1. `publishPort: "127.0.0.1:3002:3000"`, `hostname: nas` → `homepage.href=http://nas:3002/`, `homepage.widget.url=http://localhost:3002/health`; snippet matches ✅
2. Default `publishPort` → output identical to current behavior ✅
3. Snippet and compose labels agree (both derive from `hostPort`) ✅

## Tests

- `tests/docker-container-capability.test.js` (+2): hostPort derivation with differing ports; no-regression default.
- `tests/lib/utils/file-generator-python.test.js` (+2): full-generation acceptance — labels + snippet agree on `:3002`; default config unchanged.
- Full suite: **188 files, 1817 passed / 24 skipped**, 0 eslint errors, prettier clean.