### PR TITLE
fix(genproj): regenerate cloud_login.sh + helper scripts on overwrite (scripts/ is infra, not app code)

### DIFF
--- a/webapp/src/lib/utils/genproj-overwrite.js
+++ b/webapp/src/lib/utils/genproj-overwrite.js
@@ -22,13 +22,33 @@
 
 const APP_OWNED_PATH_PREFIXES = ['src/', 'tests/', 'scripts/', 'worker/', 'app/'];
 
+// Genproj-generated helper scripts that live under the app-owned `scripts/`
+// prefix but are INFRA (template-owned), not user code: cloud_login.sh and the
+// wrangler/doppler helpers are emitted by genproj and must be updated on
+// regeneration, or they go stale (e.g. parquet-peek's cloud_login.sh kept its
+// pre-doppler form — no doppler login block — through two regenerations
+// because the whole scripts/ prefix was treated as app code).
+// Genuinely user-owned scripts (e.g. the docker-container
+// `scripts/entrypoint.sh` contract) remain app-owned. Keep this list in sync
+// with the `scripts/` filePaths emitted by file-generator.js and
+// capabilities.js.
+const GENPROJ_OWNED_SCRIPTS = new Set([
+	'scripts/cloud_login.sh',
+	'scripts/run-wrangler-dev.sh',
+	'scripts/setup-wrangler-config.sh',
+	'scripts/sync-doppler-secrets.sh'
+]);
+
 /**
  * True when the path is user/app-owned code that must never be silently
- * replaced by a scaffold on regeneration.
+ * replaced by a scaffold on regeneration. Genproj-owned helper scripts under
+ * scripts/ (cloud_login.sh, wrangler/doppler helpers) are NOT app-owned: they
+ * are regenerated infra and the fresh template content must win on regen.
  * @param {string} filePath - Generated file path
  * @returns {boolean} True when the path is app-owned
  */
 export function isAppOwnedPath(filePath) {
+	if (GENPROJ_OWNED_SCRIPTS.has(filePath)) return false;
 	return APP_OWNED_PATH_PREFIXES.some((prefix) => filePath.startsWith(prefix));
 }
 

--- a/webapp/tests/lib/server/project-generator.test.js
+++ b/webapp/tests/lib/server/project-generator.test.js
@@ -327,6 +327,41 @@ describe('ProjectGeneratorService', () => {
 			);
 		});
 
+		// Round-6 (memo genproj-doppler-login): genproj-generated helper
+		// scripts under scripts/ are INFRA — a diverged cloud_login.sh must be
+		// replaced by the fresh template content on overwrite (otherwise it
+		// keeps its pre-doppler form and the cloud login flow is broken).
+		it('updates diverged genproj-owned scripts (cloud_login.sh) on overwrite but preserves user scripts', async () => {
+			const scriptFiles = [
+				{ filePath: 'scripts/cloud_login.sh', content: 'new-cloud-login' },
+				{ filePath: 'scripts/entrypoint.sh', content: 'new-entrypoint' }
+			];
+			service.services.github.getFileContent
+				.mockResolvedValueOnce('old-cloud-login-no-doppler') // scripts/cloud_login.sh diverged
+				.mockResolvedValueOnce('old-user-entrypoint'); // scripts/entrypoint.sh diverged
+
+			await service.commitFilesToRepository(repository, scriptFiles, {
+				...context,
+				overwrite: true
+			});
+
+			// cloud_login.sh is genproj infra → updated; entrypoint.sh is user
+			// code → preserved.
+			expect(service.services.github.createMultipleFiles).toHaveBeenCalledWith(
+				'owner',
+				'repo',
+				[
+					{
+						path: 'scripts/cloud_login.sh',
+						content: 'new-cloud-login',
+						message: 'Add scripts/cloud_login.sh'
+					}
+				],
+				'Initial commit: Generated project with 1 capabilities',
+				'main'
+			);
+		});
+
 		it('overwrites a diverged file when explicitly resolved to overwrite', async () => {
 			service.services.github.getFileContent.mockResolvedValue('old-diverged-content');
 

--- a/webapp/tests/lib/utils/genproj-overwrite.test.js
+++ b/webapp/tests/lib/utils/genproj-overwrite.test.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Overwrite-policy classification for genproj regeneration.
+ * Round-6 (memo genproj-doppler-login): the generated helper scripts under
+ * scripts/ (cloud_login.sh, wrangler/doppler helpers) are INFRA, not app code —
+ * otherwise a regeneration keeps the stale first-generation script (e.g. a
+ * cloud_login.sh with no doppler block) even when the capability set changed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isAppOwnedPath, isMergeTargetFile } from '$lib/utils/genproj-overwrite.js';
+
+describe('isAppOwnedPath', () => {
+	it('classifies user code under src/, tests/, worker/ and app/ as app-owned', () => {
+		expect(isAppOwnedPath('src/routes/+page.svelte')).toBe(true);
+		expect(isAppOwnedPath('tests/lib/store.test.js')).toBe(true);
+		expect(isAppOwnedPath('worker/index.js')).toBe(true);
+		expect(isAppOwnedPath('app/App.tsx')).toBe(true);
+	});
+
+	it('classifies generated infra (Dockerfile, .circleci, .devcontainer, README) as not app-owned', () => {
+		expect(isAppOwnedPath('Dockerfile')).toBe(false);
+		expect(isAppOwnedPath('.circleci/config.yml')).toBe(false);
+		expect(isAppOwnedPath('.devcontainer/.zshrc')).toBe(false);
+		expect(isAppOwnedPath('README.md')).toBe(false);
+		expect(isAppOwnedPath('docker-compose.yml')).toBe(false);
+	});
+
+	it('classifies user-owned scripts (e.g. the docker-container entrypoint contract) as app-owned', () => {
+		expect(isAppOwnedPath('scripts/entrypoint.sh')).toBe(true);
+		expect(isAppOwnedPath('scripts/backup.py')).toBe(true);
+	});
+
+	it('classifies genproj-generated helper scripts as infra, not app-owned', () => {
+		// Round-6: these are template-owned and MUST be updated on regen —
+		// a stale cloud_login.sh (pre-doppler) breaks the cloud login flow.
+		expect(isAppOwnedPath('scripts/cloud_login.sh')).toBe(false);
+		expect(isAppOwnedPath('scripts/run-wrangler-dev.sh')).toBe(false);
+		expect(isAppOwnedPath('scripts/setup-wrangler-config.sh')).toBe(false);
+		expect(isAppOwnedPath('scripts/sync-doppler-secrets.sh')).toBe(false);
+	});
+});
+
+describe('isMergeTargetFile', () => {
+	it('returns true only for devcontainer.json', () => {
+		expect(isMergeTargetFile('.devcontainer/devcontainer.json')).toBe(true);
+		expect(isMergeTargetFile('.devcontainer/Dockerfile')).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes the regeneration bug behind the user report: after regenerating `parquet-peek` (twice, adding the `doppler` capability), `scripts/cloud_login.sh` was never updated — it kept its first-generation form with **no Doppler login block**. `goose()` correctly pre-flighted auth and said *"Run: bash scripts/cloud_login.sh"*, but the script only logged into Tailscale and exited, so goose could never start.

## Root cause

`src/lib/utils/genproj-overwrite.js` classified the **entire `scripts/` prefix as app-owned code**:

```js
const APP_OWNED_PATH_PREFIXES = ['src/', 'tests/', 'scripts/', 'worker/', 'app/'];
```

On regeneration (`overwrite: true`), diverged app-owned files are preserved unless explicitly resolved to `overwrite` — so `scripts/cloud_login.sh` stayed stale across regenerations (confirmed: the file in `parquet-peek` was last touched in the **first** generation, commit `f0f532972`; both regens `16022a01` and `a04379cc` preserved it). The intent of the `scripts/` prefix was to protect user scripts like the docker-container `scripts/entrypoint.sh` contract — but genproj's own helper scripts were caught in the same net.

## Fix

- **`genproj-overwrite.js`**: new `GENPROJ_OWNED_SCRIPTS` set — `scripts/cloud_login.sh`, `scripts/run-wrangler-dev.sh`, `scripts/setup-wrangler-config.sh`, `scripts/sync-doppler-secrets.sh` — treated as **template-owned infra** (fresh template content wins on regen). User scripts (e.g. `scripts/entrypoint.sh`) remain app-owned and are still preserved. The list is kept in sync with the `scripts/` filePaths emitted by `file-generator.js` / `capabilities.js`.
- **UI**: `+page.svelte` derives conflict defaults from `isAppOwnedPath`, so a diverged `cloud_login.sh` now defaults to `overwrite` in the conflict modal too.

## Tests

- `tests/lib/utils/genproj-overwrite.test.js` (new, 5 tests): classification — user code under `src/tests/worker/app` is app-owned, generated infra is not, `scripts/entrypoint.sh` stays app-owned, all four genproj helper scripts are not.
- `tests/lib/server/project-generator.test.js` (+1): end-to-end — diverged `scripts/cloud_login.sh` is updated on overwrite while diverged `scripts/entrypoint.sh` is preserved.
- Full suite green, 0 eslint errors, prettier clean.

## Immediate unblock (already done)

`parquet-peek@main` `scripts/cloud_login.sh` was updated to the fresh genproj output (commit `22c6e9a0`) — `git pull` in the devcontainer, run `bash scripts/cloud_login.sh` (Doppler browser login), then `goose` works.

## Deploy note

Once merged + deployed to fintechnick.com, future regenerations of any project get the corrected overwrite behavior; existing projects just need the one `scripts/cloud_login.sh` update (as applied to parquet-peek).